### PR TITLE
Run managed flows internally

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -1,6 +1,6 @@
 object Version {
   val Akka = "2.3.5"
-  val AkkaStream = "0.7"
+  val AkkaStream = "0.8"
   val CommonsIO = "2.4"
   val Scalaz = "7.1.0"
   val ScalazStream = "0.5a"

--- a/streamz-akka-stream/src/test/scala/streamz/akka/stream/AkkaStreamSpec.scala
+++ b/streamz-akka-stream/src/test/scala/streamz/akka/stream/AkkaStreamSpec.scala
@@ -76,7 +76,7 @@ class AkkaStreamSpec extends TestKit(ActorSystem(classOf[AkkaStreamSpec].getSimp
 
   "stream.publish" must {
     "publish to a managed flow" in {
-      val process: Process[Task, Unit] = Process.emitAll(1 to 3).publish()(_.withSink(ForeachSink(testActor ! _)).run())
+      val process: Process[Task, Unit] = Process.emitAll(1 to 3).publish()(_.withSink(ForeachSink(testActor ! _)))()
       process.run.run
       expectMsg(1)
       expectMsg(2)
@@ -86,7 +86,7 @@ class AkkaStreamSpec extends TestKit(ActorSystem(classOf[AkkaStreamSpec].getSimp
 
   "stream.subscribe" must {
     "subscribe to a flow" in {
-      val process = subscribe(FlowFrom(1 to 3))
+      val process = FlowFrom(1 to 3).toProcess()
       process.runLog.run should be(Seq(1, 2, 3))
     }
   }


### PR DESCRIPTION
In case of managed flows the user no longer has to run the flow.
To enable getting a sink's result another optional function taking
the MaterializedFlow can be supplied.

Additionally an implicit type conversion for FlowWithSource was
added for Flow -> Process.
