### PR TITLE
Upgrade third party dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ val p2: Process[Task, Unit] = p1.publish()
   // Customize flow (done when running process)
   { source => source.toMat(sink)(Keep.right) }
   // get matrialized result (here used for cleanup)
-  { materialized => materialized.onComplete(_ => system.shutdown()) }
+  { materialized => materialized.onComplete(_ => system.terminate()) }
 
 // Run process
 p2.run.run
@@ -184,11 +184,11 @@ val p1: Process[Task, Int] = Process.emitAll(1 to 20)
 val (p2, publisher) = p1.publisher()
 // Create (un-managed) flow from publisher
 private val sink = Sink.foreach(println)
-val m = Source(publisher).runWith(sink)
+val m = Source.fromPublisher(publisher).runWith(sink)
 // Run process
 p2.run.run
 // use materialized result for cleanup
-m.onComplete(_ => system.shutdown())
+m.onComplete(_ => system.terminate())
 ```
 
 ### `Process` subscribes to flow
@@ -203,5 +203,5 @@ val p1: Process[Task, Int] = f1.toProcess()
 // Run process
 p1.map(println).run.run
 // When p1 is done, f1 must be done as well
-system.shutdown()
+system.terminate()
 ```

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -1,8 +1,8 @@
 object Version {
-  val Akka = "2.3.13"
-  val AkkaStream = "1.0"
+  val Akka = "2.4.1"
+  val AkkaStream = "2.0.1"
   val CommonsIO = "2.4"
-  val Scalaz = "7.1.2"
-  val ScalazStream = "0.7.2a"
+  val Scalaz = "7.2.0"
+  val ScalazStream = "0.8"
   val Scalatest = "2.2.4"
 }

--- a/streamz-akka-camel/build.sbt
+++ b/streamz-akka-camel/build.sbt
@@ -2,5 +2,5 @@ name := "streamz-akka-camel"
 
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-camel" % Version.Akka,
-  "org.apache.camel" % "camel-ftp" % "2.10.3" % "test"
+  "org.apache.camel" % "camel-ftp" % "2.13.4" % "test"
 )

--- a/streamz-akka-camel/src/main/scala/streamz/akka/camel/package.scala
+++ b/streamz-akka-camel/src/main/scala/streamz/akka/camel/package.scala
@@ -46,7 +46,7 @@ package object camel {
     def go(p: Process[Task, A]): Task[A] = p.step match {
       case Step(Emit(os), cont) =>
         if (os.isEmpty) go(cont.continue) else Task.now(os.head)
-      case Step(Await(rq, rcv), cont) =>
+      case Step(Await(rq, rcv, preempt), cont) =>
         rq.attempt.flatMap { r =>
           go(rcv(EarlyCause.fromTaskResult(r)).run +: cont)
         }
@@ -95,8 +95,8 @@ package object camel {
     def send(uri:String)(implicit system: ActorSystem): Process[Task,Unit] =
       self.to(sender[O](uri))
 
-    def sendW(uri: String)(implicit system: ActorSystem): Process[Task,O] = {
-      self.flatMap(o => Process.tell(o) ++ Process.emitO(o)).drainW(sender[O](uri))
+    def sendW(uri: String)(implicit system: ActorSystem): Process[Task, O] = {
+      self.flatMap(o => Process.tell(o) ++ Process.emitO(o)).observeW(sender[O](uri)).stripW
     }
   }
 

--- a/streamz-akka-camel/src/test/scala/streamz/akka/camel/CamelSpec.scala
+++ b/streamz-akka-camel/src/test/scala/streamz/akka/camel/CamelSpec.scala
@@ -24,7 +24,7 @@ class CamelSpec extends TestKit(ActorSystem("test")) with WordSpecLike with Matc
 
   override protected def afterAll(): Unit = {
     consumerTemplate.stop()
-    system.shutdown()
+    system.terminate()
   }
 
   class Service {

--- a/streamz-akka-persistence/build.sbt
+++ b/streamz-akka-persistence/build.sbt
@@ -1,6 +1,7 @@
 name := "streamz-akka-persistence"
 
 libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-persistence-experimental" % Version.Akka,
+  "com.typesafe.akka" %% "akka-persistence" % Version.Akka,
+  "org.iq80.leveldb" % "leveldb" % "0.7",
   "commons-io" % "commons-io" % Version.CommonsIO % "test"
 )

--- a/streamz-akka-persistence/src/main/scala/streamz/akka/persistence/package.scala
+++ b/streamz-akka-persistence/src/main/scala/streamz/akka/persistence/package.scala
@@ -63,7 +63,7 @@ package object persistence {
     import JournalWriter._
 
     def receiveCommand = {
-      case Stop(cb) => defer(cb) { cb =>
+      case Stop(cb) => deferAsync(cb) { cb =>
         // ensures that actor is stopped after Stop has
         // been looped through journal i.e. all previous
         // messages have been persisted
@@ -79,10 +79,9 @@ package object persistence {
       case _ =>
     }
 
-    override def preStart(): Unit =
-      // recover last sequence number
-      // but do not replay messages
-      self ! Recover(replayMax = 0L)
+    // recover last sequence number
+    // but do not replay messages
+    override def recovery = Recovery(toSequenceNr = 0L)
   }
 
   private object JournalWriter {

--- a/streamz-akka-persistence/src/test/resources/application.conf
+++ b/streamz-akka-persistence/src/test/resources/application.conf
@@ -1,4 +1,6 @@
 akka.persistence {
+  journal.plugin = "akka.persistence.journal.leveldb"
+  snapshot-store.plugin = "akka.persistence.snapshot-store.local"
   journal.leveldb {
     dir = "target/journal"
     native = off

--- a/streamz-akka-persistence/src/test/scala/streamz/akka/persistence/PersistenceSpec.scala
+++ b/streamz-akka-persistence/src/test/scala/streamz/akka/persistence/PersistenceSpec.scala
@@ -15,7 +15,7 @@ import org.scalatest._
 
 class PersistenceSpec extends TestKit(ActorSystem("test")) with WordSpecLike with Matchers with BeforeAndAfterAll {
   override protected def afterAll(): Unit = {
-    system.shutdown()
+    system.terminate()
     List(
       "akka.persistence.journal.leveldb.dir",
       "akka.persistence.snapshot-store.local.dir")

--- a/streamz-akka-stream/build.sbt
+++ b/streamz-akka-stream/build.sbt
@@ -2,6 +2,5 @@ name := "streamz-akka-stream"
 
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-actor" % Version.Akka,
-  "com.typesafe.akka" %% "akka-persistence-experimental" % Version.Akka,
   "com.typesafe.akka" %% "akka-stream-experimental" % Version.AkkaStream
 )

--- a/streamz-akka-stream/src/test/scala/streamz/akka/stream/example/AkkaStreamExample.scala
+++ b/streamz-akka-stream/src/test/scala/streamz/akka/stream/example/AkkaStreamExample.scala
@@ -27,7 +27,7 @@ object ProcessToManagedFlow extends App {
     // Customize Source (done when running process)
     { source => source.toMat(sink)(Keep.right) }
     // get result from sink (here used for cleanup)
-    { materialized => materialized.onComplete(_ => system.shutdown()) }
+    { materialized => materialized.onComplete(_ => system.terminate()) }
 
   // Run process
   p2.run.run
@@ -42,11 +42,11 @@ object ProcessToUnManagedFlow extends App {
   val (p2, publisher) = p1.publisher()
   // Create (un-managed) flow from publisher
   private val sink = Sink.foreach(println)
-  val m = Source(publisher).runWith(sink)
+  val m = Source.fromPublisher(publisher).runWith(sink)
   // Run process
   p2.run.run
   // use materialized result for cleanup
-  m.onComplete(_ => system.shutdown())
+  m.onComplete(_ => system.terminate())
 }
 
 object FlowToProcess extends App {
@@ -59,7 +59,7 @@ object FlowToProcess extends App {
   // Run process
   p1.map(println).run.run
   // When p1 is done, f1 must be done as well
-  system.shutdown()
+  system.terminate()
 }
 
 object FlowToProcessToManagedFlow extends App {
@@ -68,7 +68,7 @@ object FlowToProcessToManagedFlow extends App {
   val f1: Source[Int, Unit] = Source(1 to 20)
   val p1: Process[Task, Int] = subscribe(f1)
   val p2: Process[Task, Unit] = p1.publish() { flow =>
-    flow.map(println).to(Sink.onComplete(_ => system.shutdown())) // use sink for cleanup
+    flow.map(println).to(Sink.onComplete(_ => system.terminate())) // use sink for cleanup
   }() // and ignore sink's "result"
   p2.run.run
 }


### PR DESCRIPTION
- akka: 2.3 -> 2.4
- akka-stream: 1.0 -> 2.0
- scalaz: 7.1 -> 7.2
- scalaz-stream: 0.7 -> 0.8

For this:
- all:
  - replace shutdown by terminate
- akka-Camel
  - new Process-API
- akka-persistence:
  - still depends on deprecated PersistentView
  - override aroundReceive to handle RecoverySuccess
  - defer -> deferAsync
  - replace Recover-message by Recovery-configuration
  - configure leveldb explicitly
- akka-stream:
  - new akka-stream API