### PR TITLE
Versions update

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ organization in ThisBuild := "com.github.krasserm"
 
 version in ThisBuild := "0.4-SNAPSHOT"
 
-scalaVersion in ThisBuild := "2.11.7"
+scalaVersion in ThisBuild := "2.11.8"
 
 resolvers in ThisBuild += "Scalaz Bintray Repo" at "http://dl.bintray.com/scalaz/releases"
 

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -1,8 +1,8 @@
 object Version {
-  val Akka = "2.4.1"
-  val AkkaStream = "2.0.1"
+  val Akka = "2.4.6"
+  val AkkaStream = "2.4.6"
   val CommonsIO = "2.4"
-  val Scalaz = "7.2.0"
-  val ScalazStream = "0.8"
+  val Scalaz = "7.2.2"
+  val ScalazStream = "0.8a"
   val Scalatest = "2.2.4"
 }

--- a/streamz-akka-camel/src/main/scala/streamz/akka/camel/package.scala
+++ b/streamz-akka-camel/src/main/scala/streamz/akka/camel/package.scala
@@ -27,7 +27,7 @@ package object camel {
   def receive[O](uri: String)(implicit system: ActorSystem, CT: ClassTag[O]): Process[Task,O] = {
     class ConsumerEndpoint(val endpointUri: String, queue: scalaz.stream.async.mutable.Queue[O]) extends Consumer {
       def receive = {
-        case msg: CamelMessage => queue.enqueueOne(msg.bodyAs(CT, camelContext)).run
+        case msg: CamelMessage => queue.enqueueOne(msg.bodyAs(CT, camelContext)).unsafePerformSync
       }
     }
 

--- a/streamz-akka-camel/src/test/scala/streamz/akka/camel/CamelSpec.scala
+++ b/streamz-akka-camel/src/test/scala/streamz/akka/camel/CamelSpec.scala
@@ -34,13 +34,13 @@ class CamelSpec extends TestKit(ActorSystem("test")) with WordSpecLike with Matc
   "A receiver" must {
     "produce a discrete stream" in {
       1 to 3 foreach { i => producerTemplate.sendBody("seda:q0", i) }
-      receive[Int]("seda:q0").take(3).runLog.run should be(Seq(1, 2, 3))
+      receive[Int]("seda:q0").take(3).runLog.unsafePerformSync should be(Seq(1, 2, 3))
     }
   }
 
   "A terminal sender" must {
     "send to an endpoint" in {
-      receive[Int]("seda:q1").send("seda:q2").take(3).run.runAsync {
+      receive[Int]("seda:q1").send("seda:q2").take(3).run.unsafePerformAsync {
         case \/-(r) => testActor ! "done"
         case -\/(e) =>
       }
@@ -55,7 +55,7 @@ class CamelSpec extends TestKit(ActorSystem("test")) with WordSpecLike with Matc
 
   "An intermediate sender" must {
     "send to an endpoint and continue with the sent message" in {
-      receive[Int]("seda:q3").sendW("seda:q4").take(3).runLog.runAsync {
+      receive[Int]("seda:q3").sendW("seda:q4").take(3).runLog.unsafePerformAsync {
         case \/-(r) => testActor ! r
         case -\/(e) =>
       }
@@ -71,11 +71,11 @@ class CamelSpec extends TestKit(ActorSystem("test")) with WordSpecLike with Matc
   "A requestor" must {
     "request from an endpoint and continue with the response message" in {
       registry.put("service", new Service)
-      Process(1, 2, 3).request[Int]("bean:service?method=plusOne").runLog.run should be(Seq(2, 3, 4))
+      Process(1, 2, 3).request[Int]("bean:service?method=plusOne").runLog.unsafePerformSync should be(Seq(2, 3, 4))
     }
     "convert response message types using a Camel type converter" in {
       registry.put("service", new Service)
-      Process("1", "2", "3").request[Int]("bean:service?method=plusOne").runLog.run should be(Seq(2, 3, 4))
+      Process("1", "2", "3").request[Int]("bean:service?method=plusOne").runLog.unsafePerformSync should be(Seq(2, 3, 4))
     }
   }
 }

--- a/streamz-akka-camel/src/test/scala/streamz/example/CamelExample.scala
+++ b/streamz-akka-camel/src/test/scala/streamz/example/CamelExample.scala
@@ -10,9 +10,8 @@ import streamz.akka.camel._
 object CamelExample {
   implicit val system = ActorSystem("example")
 
-  val p: Process[Task,Unit] =
-  // receive from endpoint
-    receive[String]("seda:q1")
+  val p: Process[Task, Unit] = // receive from endpoint
+  receive[String]("seda:q1")
     // in-only message exchange with endpoint and continue stream with in-message
     .sendW("seda:q3")
     // in-only message exchange with endpoint and continue stream with out-message
@@ -24,10 +23,10 @@ object CamelExample {
   val t: Task[Unit] = p.run
 
   // run task (side effects only here) ...
-  t.run
+  t.unsafePerformSync
 
-  val p1: Process[Task,String] = receive[String]("seda:q1")
-  val p2: Process[Task,Unit] = p1.send("seda:q2")
-  val p3: Process[Task,String] = p1.sendW("seda:q3")
-  val p4: Process[Task,Int] = p1.request[Int]("bean:service?method=length")
+  val p1: Process[Task, String] = receive[String]("seda:q1")
+  val p2: Process[Task, Unit] = p1.send("seda:q2")
+  val p3: Process[Task, String] = p1.sendW("seda:q3")
+  val p4: Process[Task, Int] = p1.request[Int]("bean:service?method=length")
 }

--- a/streamz-akka-camel/src/test/scala/streamz/example/FtpExample.scala
+++ b/streamz-akka-camel/src/test/scala/streamz/example/FtpExample.scala
@@ -31,7 +31,7 @@ object FtpExample extends App {
     .to(io.stdOutLines)
 
   // side effects here ...
-  printUpper.run.run
+  printUpper.run.unsafePerformSync
 
 
   // To process files from a local directory, change the enpointUri to

--- a/streamz-akka-stream/build.sbt
+++ b/streamz-akka-stream/build.sbt
@@ -2,5 +2,5 @@ name := "streamz-akka-stream"
 
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-actor" % Version.Akka,
-  "com.typesafe.akka" %% "akka-stream-experimental" % Version.AkkaStream
+  "com.typesafe.akka" %% "akka-stream" % Version.AkkaStream
 )

--- a/streamz-akka-stream/src/main/scala/streamz/akka/stream/package.scala
+++ b/streamz-akka-stream/src/main/scala/streamz/akka/stream/package.scala
@@ -48,7 +48,7 @@ package object stream { outer =>
   def publish[I : ClassTag, Mat, O](process: Process[Task, I],
                                     strategyFactory: RequestStrategyFactory = maxInFlightStrategyFactory(10),
                                     name: Option[String] = None)
-                                   (f: Source[I, Unit] => RunnableGraph[Mat])
+                                   (f: Source[I, akka.NotUsed] => RunnableGraph[Mat])
                                    (m: Mat => Unit = (_: Mat) => ())
                                    (implicit actorRefFactory: ActorRefFactory, materializer: Materializer): Process[Task, Unit] =
   {
@@ -82,7 +82,7 @@ package object stream { outer =>
   implicit class ProcessSyntax[I : ClassTag](self: Process[Task,I]) {
     def publish[O, Mat](strategyFactory: RequestStrategyFactory = maxInFlightStrategyFactory(10),
                         name: Option[String] = None)
-                       (f: Source[I, Unit] => RunnableGraph[Mat])
+                       (f: Source[I, akka.NotUsed] => RunnableGraph[Mat])
                        (m: Mat => Unit = (_: Mat) => ())
                        (implicit actorRefFactory: ActorRefFactory, materializer: Materializer): Process[Task, Unit] =
       outer.publish(self, strategyFactory)(f)(m)
@@ -102,7 +102,7 @@ package object stream { outer =>
 
   private def adapterSink[I, Mat, O](adapterProps: Props,
                                      name: Option[String] = None,
-                                     f: Source[I, Unit] => RunnableGraph[Mat],
+                                     f: Source[I, akka.NotUsed] => RunnableGraph[Mat],
                                      m: Mat => Unit)
                                     (implicit actorRefFactory: ActorRefFactory, materializer: Materializer): Sink[Task, I] =
     adapterSink {


### PR DESCRIPTION
This PR updates the code to be able to work with Play 2.5.3 and use streams from scalaz-stream 0.8a

I tested this converting a scalaz stream to a source for WebSockets under play

All tests are passing