### PR TITLE
Inbound in-out message exchange processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,26 @@ Streamz
 [![Gitter](https://badges.gitter.im/krasserm/streamz.svg)](https://gitter.im/krasserm/streamz?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [![Build Status](https://travis-ci.org/krasserm/streamz.svg?branch=master)](https://travis-ci.org/krasserm/streamz)
 
-Streamz is a combinator library for integrating [Functional Streams for Scala](https://github.com/functional-streams-for-scala/fs2) (FS2), [Akka Streams](http://doc.akka.io/docs/akka/2.4/scala/stream/index.html) and [Apache Camel endpoints](http://camel.apache.org/components.html). It integrates
+Streamz provides combinator libraries for integrating [Functional Streams for Scala](https://github.com/functional-streams-for-scala/fs2) (FS2), [Akka Streams](http://doc.akka.io/docs/akka/2.4/scala/stream/index.html) and [Apache Camel endpoints](http://camel.apache.org/components.html). They integrate
 
 - **Apache Camel with Akka Streams:** Camel endpoints can be integrated into Akka Stream applications with the [Camel DSL for Akka Streams](streamz-camel-akka/README.md).
 - **Apache Camel with FS2:** Camel endpoints can be integrated into FS2 applications with the [Camel DSL for FS2](streamz-camel-fs2/README.md).
 - **Akka Streams with FS2:** Akka Stream `Source`s, `Flow`s and `Sink`s can be converted to FS2 `Stream`s, `Pipe`s and `Sink`s, respectively, and vice versa with [Stream converters](streamz-converter/README.md).
 
 ![Streamz intro](images/streamz-intro.png)
+
+Dependencies
+------------
+
+Streamz artifacts are available for Scala 2.11 and 2.12:
+
+    resolvers += "krasserm at bintray" at "http://dl.bintray.com/krasserm/maven"
+
+    libraryDependencies += "com.github.krasserm" %% "streamz-camel-akka" % "0.7"
+
+    libraryDependencies += "com.github.krasserm" %% "streamz-camel-fs2" % "0.7"
+
+    libraryDependencies += "com.github.krasserm" %% "streamz-converter" % "0.7"
 
 Documentation
 -------------
@@ -25,19 +38,6 @@ API docs
 
 - [API docs for Scala 2.12](http://krasserm.github.io/streamz/scala-2.12/unidoc/index.html)
 - [API docs for Scala 2.11](http://krasserm.github.io/streamz/scala-2.11/unidoc/index.html)
-
-Dependencies
-------------
-
-Streamz artifacts are available for Scala 2.11 and 2.12:
-
-    resolvers += "krasserm at bintray" at "http://dl.bintray.com/krasserm/maven"
-
-    libraryDependencies += "com.github.krasserm" %% "streamz-camel-akka" % "0.7"
-
-    libraryDependencies += "com.github.krasserm" %% "streamz-camel-fs2" % "0.7"
-
-    libraryDependencies += "com.github.krasserm" %% "streamz-converter" % "0.7"
 
 External examples
 -----------------

--- a/streamz-camel-akka/src/main/java/streamz/camel/akka/javadsl/JavaDsl.java
+++ b/streamz-camel-akka/src/main/java/streamz/camel/akka/javadsl/JavaDsl.java
@@ -19,6 +19,7 @@ package streamz.camel.akka.javadsl;
 import akka.NotUsed;
 import akka.stream.FlowShape;
 import akka.stream.Graph;
+import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Source;
 import streamz.camel.StreamContext;
 import streamz.camel.StreamMessage;
@@ -35,6 +36,26 @@ public interface JavaDsl {
     /** Delegates to {@link streamz.camel.akka.scaladsl.receiveBody scaladsl.receiveBody} */
     default <A> Source<A, NotUsed> receiveBody(String uri, Class<A> clazz) {
         return new JavaDslDef(streamContext()).receiveBody(uri, clazz);
+    }
+
+    /** Delegates to {@link streamz.camel.akka.scaladsl.receiveRequest scaladsl.receiveRequest} */
+    default <A, B> Flow<StreamMessage<A>, StreamMessage<B>, NotUsed> receiveRequest(String uri, Integer capacity, Class<B> clazz) {
+        return new JavaDslDef(streamContext()).receiveRequest(uri, capacity, clazz);
+    }
+
+    /** Delegates to {@link streamz.camel.akka.scaladsl.receiveRequest scaladsl.receiveRequest} */
+    default <A, B> Flow<StreamMessage<A>, StreamMessage<B>, NotUsed> receiveRequest(String uri, Class<B> clazz) {
+        return new JavaDslDef(streamContext()).receiveRequest(uri, clazz);
+    }
+
+    /** Delegates to {@link streamz.camel.akka.scaladsl.receiveRequestBody scaladsl.receiveRequestBody} */
+    default <A, B> Flow<A, B, NotUsed> receiveRequestBody(String uri, Integer capacity, Class<B> clazz) {
+        return new JavaDslDef(streamContext()).receiveRequestBody(uri, capacity, clazz);
+    }
+
+    /** Delegates to {@link streamz.camel.akka.scaladsl.receiveRequestBody scaladsl.receiveRequestBody} */
+    default <A, B> Flow<A, B, NotUsed> receiveRequestBody(String uri, Class<B> clazz) {
+        return new JavaDslDef(streamContext()).receiveRequestBody(uri, clazz);
     }
 
     /** Delegates to {@link streamz.camel.akka.scaladsl.send scaladsl.send} */
@@ -57,23 +78,27 @@ public interface JavaDsl {
         return sendBody(uri, 1);
     }
 
-    /** Delegates to {@link streamz.camel.akka.scaladsl.request scaladsl.request} */
-    default <A, B> Graph<FlowShape<StreamMessage<A>, StreamMessage<B>>, NotUsed> request(String uri, int parallelism, Class<B> clazz) {
-        return new JavaDslDef(streamContext()).request(uri, parallelism, clazz);
+    /** Delegates to {@link streamz.camel.akka.scaladsl.sendRequest scaladsl.sendRequest} */
+    default <A, B> Graph<FlowShape<StreamMessage<A>, StreamMessage<B>>, NotUsed> sendRequest(String uri, int parallelism, Class<B> clazz) {
+        return new JavaDslDef(streamContext()).sendRequest(uri, parallelism, clazz);
     }
 
-    /** Delegates to {@link streamz.camel.akka.scaladsl.request scaladsl.request} */
-    default <A, B> Graph<FlowShape<StreamMessage<A>, StreamMessage<B>>, NotUsed> request(String uri, Class<B> clazz) {
-        return request(uri, 1, clazz);
+    /** Delegates to {@link streamz.camel.akka.scaladsl.sendRequest scaladsl.sendRequest} */
+    default <A, B> Graph<FlowShape<StreamMessage<A>, StreamMessage<B>>, NotUsed> sendRequest(String uri, Class<B> clazz) {
+        return new JavaDslDef(streamContext()).sendRequest(uri, clazz);
     }
 
-    /** Delegates to {@link streamz.camel.akka.scaladsl.requestBody scaladsl.requestBody} */
-    default <A, B> Graph<FlowShape<A, B>, NotUsed> requestBody(String uri, int parallelism, Class<B> clazz) {
-        return new JavaDslDef(streamContext()).requestBody(uri, parallelism, clazz);
+    /** Delegates to {@link streamz.camel.akka.scaladsl.sendRequestBody scaladsl.sendRequestBody} */
+    default <A, B> Graph<FlowShape<A, B>, NotUsed> sendRequestBody(String uri, int parallelism, Class<B> clazz) {
+        return new JavaDslDef(streamContext()).sendRequestBody(uri, parallelism, clazz);
     }
 
-    /** Delegates to {@link streamz.camel.akka.scaladsl.requestBody scaladsl.requestBody} */
-    default <A, B> Graph<FlowShape<A, B>, NotUsed> requestBody(String uri, Class<B> clazz) {
-        return requestBody(uri, 1 , clazz);
+    /** Delegates to {@link streamz.camel.akka.scaladsl.sendRequestBody scaladsl.sendRequestBody} */
+    default <A, B> Graph<FlowShape<A, B>, NotUsed> sendRequestBody(String uri, Class<B> clazz) {
+        return new JavaDslDef(streamContext()).sendRequestBody(uri, clazz);
+    }
+
+    default <A> Flow<A, A, NotUsed> reply() {
+        return Flow.create();
     }
 }

--- a/streamz-camel-akka/src/main/scala/streamz/camel/akka/EndpointConsumerReplier.scala
+++ b/streamz-camel-akka/src/main/scala/streamz/camel/akka/EndpointConsumerReplier.scala
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2014 - 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package streamz.camel.akka
+
+import java.util.concurrent.{ ArrayBlockingQueue, TimeUnit }
+
+import akka.stream._
+import akka.stream.stage._
+import org.apache.camel.{ AsyncCallback => CamelAsyncCallback, _ }
+import streamz.camel.{ StreamContext, StreamMessage }
+
+import scala.collection.mutable
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.reflect.ClassTag
+import scala.util.{ Failure, Success, Try }
+
+private case class AsyncExchange(exchange: Exchange, callback: CamelAsyncCallback)
+
+private class AsyncExchangeProcessor(capacity: Int) extends AsyncProcessor {
+  val receivedExchanges = new ArrayBlockingQueue[AsyncExchange](capacity)
+
+  def fail(t: Throwable): Unit =
+    receivedExchanges.iterator()
+
+  override def process(exchange: Exchange): Unit =
+    ???
+
+  override def process(exchange: Exchange, callback: CamelAsyncCallback): Boolean = {
+    receivedExchanges.put(AsyncExchange(exchange, callback))
+    false
+  }
+}
+
+private[akka] class EndpointConsumerReplier[A, B](uri: String, capacity: Int)(implicit streamContext: StreamContext, tag: ClassTag[B])
+    extends GraphStage[FlowShape[StreamMessage[A], StreamMessage[B]]] {
+
+  val in: Inlet[StreamMessage[A]] = Inlet("EndpointConsumerReplier.in")
+  val out: Outlet[StreamMessage[B]] = Outlet("EndpointConsumerReplier.out")
+
+  override val shape: FlowShape[StreamMessage[A], StreamMessage[B]] = FlowShape.of(in, out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new GraphStageLogic(shape) {
+      private val processor = new AsyncExchangeProcessor(capacity)
+      private val emittedExchanges = mutable.Queue.empty[AsyncExchange]
+      private val consumedCallback = getAsyncCallback(consumed)
+
+      private var consuming: Boolean = false
+      private var consumer: Consumer = _
+
+      setHandler(in, new InHandler {
+        override def onPush(): Unit = {
+          val AsyncExchange(ce, ac) = emittedExchanges.dequeue()
+          ce.setOut(grab(in).camelMessage)
+          ac.done(false)
+          pull(in)
+          if (!consuming && isAvailable(out)) consumeAsync()
+        }
+      })
+
+      setHandler(out, new OutHandler {
+        override def onPull(): Unit =
+          if (!consuming && hasCapacity) consumeAsync()
+      })
+
+      private implicit def ec: ExecutionContext =
+        materializer.executionContext
+
+      private def hasCapacity: Boolean =
+        emittedExchanges.size < capacity
+
+      private def consumeAsync(): Unit = {
+        Future(processor.receivedExchanges.poll(500, TimeUnit.MILLISECONDS)).foreach(consumedCallback.invoke)
+        consuming = true
+      }
+
+      private def consumed(asyncExchange: AsyncExchange): Unit = {
+        consuming = false
+        asyncExchange match {
+          case null =>
+            if (!isClosed(out)) consumeAsync()
+          case ae @ AsyncExchange(ce, ac) if ce.getPattern != ExchangePattern.InOut =>
+            ac.done(false)
+            failStage(new IllegalArgumentException(s"Exchange pattern ${ExchangePattern.InOut} expected but was ${ce.getPattern}"))
+          case ae @ AsyncExchange(ce, ac) if ce.getException ne null =>
+            ac.done(false)
+            failStage(ce.getException)
+          case ae @ AsyncExchange(ce, ac) =>
+            Try(StreamMessage.from[B](ce.getIn)) match {
+              case Success(m) =>
+                push(out, m)
+                emittedExchanges.enqueue(ae)
+                if (hasCapacity && isAvailable(out)) consumeAsync()
+              case Failure(e) =>
+                ce.setException(e)
+                ac.done(false)
+                failStage(e)
+            }
+        }
+      }
+
+      override def preStart(): Unit = {
+        consumer = streamContext.consumer(uri, processor)
+        consumer.start()
+        pull(in)
+      }
+    }
+}

--- a/streamz-camel-akka/src/main/scala/streamz/camel/akka/javadsl/JavaDslDef.scala
+++ b/streamz-camel-akka/src/main/scala/streamz/camel/akka/javadsl/JavaDslDef.scala
@@ -18,8 +18,7 @@ package streamz.camel.akka.javadsl
 
 import akka.NotUsed
 import akka.stream.{ FlowShape, Graph }
-import akka.stream.javadsl.Source
-
+import akka.stream.javadsl.{ Flow, Source }
 import streamz.camel.{ StreamContext, StreamMessage }
 import streamz.camel.akka.scaladsl
 
@@ -32,15 +31,33 @@ private class JavaDslDef(streamContext: StreamContext) {
   def receiveBody[A](uri: String, clazz: Class[A]): Source[A, NotUsed] =
     Source.fromGraph(scaladsl.receiveBody(uri)(streamContext, ClassTag(clazz)))
 
+  def receiveRequest[A, B](uri: String, capacity: Int, clazz: Class[B]): Flow[StreamMessage[A], StreamMessage[B], NotUsed] =
+    Flow.fromGraph(scaladsl.receiveRequest(uri, capacity)(streamContext, ClassTag(clazz)))
+
+  def receiveRequest[A, B](uri: String, clazz: Class[B]): Flow[StreamMessage[A], StreamMessage[B], NotUsed] =
+    Flow.fromGraph(scaladsl.receiveRequest(uri)(streamContext, ClassTag(clazz)))
+
+  def receiveRequestBody[A, B](uri: String, capacity: Int, clazz: Class[B]): Flow[A, B, NotUsed] =
+    Flow.fromGraph(scaladsl.receiveRequestBody(uri, capacity)(streamContext, ClassTag(clazz)))
+
+  def receiveRequestBody[A, B](uri: String, clazz: Class[B]): Flow[A, B, NotUsed] =
+    Flow.fromGraph(scaladsl.receiveRequestBody(uri)(streamContext, ClassTag(clazz)))
+
   def send[A](uri: String, parallelism: Int): Graph[FlowShape[StreamMessage[A], StreamMessage[A]], NotUsed] =
     scaladsl.send[A](uri, parallelism)(streamContext)
 
   def sendBody[A](uri: String, parallelism: Int): Graph[FlowShape[A, A], NotUsed] =
     scaladsl.sendBody[A](uri, parallelism)(streamContext)
 
-  def request[A, B](uri: String, parallelism: Int, clazz: Class[B]): Graph[FlowShape[StreamMessage[A], StreamMessage[B]], NotUsed] =
-    scaladsl.request[A, B](uri, parallelism)(streamContext, ClassTag(clazz))
+  def sendRequest[A, B](uri: String, parallelism: Int, clazz: Class[B]): Graph[FlowShape[StreamMessage[A], StreamMessage[B]], NotUsed] =
+    scaladsl.sendRequest[A, B](uri, parallelism)(streamContext, ClassTag(clazz))
 
-  def requestBody[A, B](uri: String, parallelism: Int, clazz: Class[B]): Graph[FlowShape[A, B], NotUsed] =
-    scaladsl.requestBody[A, B](uri, parallelism)(streamContext, ClassTag(clazz))
+  def sendRequest[A, B](uri: String, clazz: Class[B]): Graph[FlowShape[StreamMessage[A], StreamMessage[B]], NotUsed] =
+    scaladsl.sendRequest[A, B](uri)(streamContext, ClassTag(clazz))
+
+  def sendRequestBody[A, B](uri: String, parallelism: Int, clazz: Class[B]): Graph[FlowShape[A, B], NotUsed] =
+    scaladsl.sendRequestBody[A, B](uri, parallelism)(streamContext, ClassTag(clazz))
+
+  def sendRequestBody[A, B](uri: String, clazz: Class[B]): Graph[FlowShape[A, B], NotUsed] =
+    scaladsl.sendRequestBody[A, B](uri)(streamContext, ClassTag(clazz))
 }

--- a/streamz-camel-akka/src/test/scala/streamz/camel/akka/EndpointConsumerReplierSpec.scala
+++ b/streamz-camel-akka/src/test/scala/streamz/camel/akka/EndpointConsumerReplierSpec.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2014 - 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package streamz.camel.akka
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Keep
+import akka.stream.testkit.scaladsl.{ TestSink, TestSource }
+import akka.stream.testkit.{ TestPublisher, TestSubscriber }
+import akka.testkit.TestKit
+import org.apache.camel.ExchangePattern
+import org.scalatest.concurrent.Eventually
+import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
+import streamz.camel.{ StreamContext, StreamMessage }
+
+import scala.concurrent.duration._
+import scala.reflect.ClassTag
+
+class EndpointConsumerReplierSpec extends TestKit(ActorSystem("test")) with WordSpecLike with Matchers with BeforeAndAfterAll with Eventually {
+  implicit val materializer = ActorMaterializer()
+  implicit val context = StreamContext()
+
+  import context._
+
+  override def afterAll(): Unit = {
+    context.stop()
+    materializer.shutdown()
+    TestKit.shutdownActorSystem(system)
+  }
+
+  def awaitEndpointRegistration(uri: String): Unit = {
+    eventually { camelContext.getEndpoint(uri) should not be null }
+  }
+
+  def publisherAndSubscriber[A, B](uri: String, capacity: Int)(implicit tag: ClassTag[B]): (TestPublisher.Probe[StreamMessage[A]], TestSubscriber.Probe[StreamMessage[B]]) = {
+    val pubSub = TestSource.probe[StreamMessage[A]].viaMat(new EndpointConsumerReplier[A, B](uri, capacity))(Keep.left).toMat(TestSink.probe[StreamMessage[B]])(Keep.both).run()
+    awaitEndpointRegistration(uri)
+    pubSub
+  }
+
+  "An EndpointConsumerReplier" must {
+    "consume a message from an endpoint and reply to that endpoint" in {
+      val uri = "direct:d1"
+      val (pub, sub) = publisherAndSubscriber[String, String](uri, 3)
+
+      val exchange = context.createExchange(StreamMessage("a", Map("foo" -> "bar")), ExchangePattern.InOut)
+      val resf = producerTemplate.asyncSend(uri, exchange)
+
+      val req = sub.requestNext()
+      req.body should be("a")
+      req.headers("foo") should be("bar")
+
+      pub.sendNext(StreamMessage("re-a", Map("foo" -> "baz")))
+      resf.get.getOut.getBody should be("re-a")
+      resf.get.getOut.getHeader("foo") should be("baz")
+    }
+    "limit the number of active requests to given capacity" in {
+      val uri = "direct:d2"
+      val (pub, sub) = publisherAndSubscriber[String, String](uri, capacity = 2)
+
+      val req = Seq("a", "b", "c")
+      val res = Seq("re-a", "re-b", "re-c")
+
+      sub.request(3)
+
+      val f1 = producerTemplate.asyncRequestBody(uri, req.head)
+      sub.expectNext().body should be(req.head)
+
+      val f2 = producerTemplate.asyncRequestBody(uri, req(1))
+      sub.expectNext().body should be(req(1))
+
+      val f3 = producerTemplate.asyncRequestBody(uri, req(2))
+      sub.expectNoMsg(100.millis)
+
+      pub.sendNext(StreamMessage(res.head))
+      sub.expectNext().body should be(req(2))
+
+      pub.sendNext(StreamMessage(res(1)))
+      pub.sendNext(StreamMessage(res(2)))
+
+      Seq(f1, f2, f3).map(_.get) should be(res)
+    }
+    "error the stream if a message exchange with the endpoint failed" in {
+      val uri = "direct:d3"
+      val (pub, sub) = publisherAndSubscriber[String, String](uri, 3)
+
+      val exchange = createExchange(StreamMessage("a"), ExchangePattern.InOut)
+      exchange.setException(new Exception("boom"))
+      producerTemplate.asyncSend(uri, exchange)
+
+      sub.request(1)
+      sub.expectError().getMessage should be("boom")
+    }
+    "error the stream if a message exchange is not in-out" in {
+      val uri = "direct:d4"
+      val (pub, sub) = publisherAndSubscriber[String, String](uri, 3)
+
+      val exchange = createExchange(StreamMessage("a"), ExchangePattern.InOnly)
+      producerTemplate.asyncSend(uri, exchange)
+
+      sub.request(1)
+      sub.expectError().getMessage should be("Exchange pattern InOut expected but was InOnly")
+    }
+  }
+}

--- a/streamz-camel-context/src/main/scala/streamz/camel/StreamContext.scala
+++ b/streamz-camel-context/src/main/scala/streamz/camel/StreamContext.scala
@@ -68,16 +68,28 @@ object StreamContext {
  */
 class StreamContext(val camelContext: CamelContext) {
   /**
+   * A Camel producer template created from `camelContext`.
+   */
+  lazy val producerTemplate: ProducerTemplate =
+    camelContext.createProducerTemplate()
+
+  /**
    * A Camel consumer template created from `camelContext`.
    */
   lazy val consumerTemplate: ConsumerTemplate =
     camelContext.createConsumerTemplate()
 
   /**
-   * A Camel producer template created from `camelContext`.
+   * A Camel consumer for given `uri`. If the corresponding endpoint doesn't exist yet, it is
+   * created and started. The returned consumer must be started (and stopped) by the caller.
    */
-  lazy val producerTemplate: ProducerTemplate =
-    camelContext.createProducerTemplate()
+  def consumer(uri: String, processor: AsyncProcessor): Consumer = {
+    val endpoint = camelContext.getEndpoint(uri)
+    if (!camelContext.getEndpoints.contains(endpoint)) {
+      endpoint.start()
+    }
+    endpoint.createConsumer(processor)
+  }
 
   /**
    * Creates a Camel [[Exchange]] of given `pattern` and input `message`.

--- a/streamz-camel-fs2/README.md
+++ b/streamz-camel-fs2/README.md
@@ -1,7 +1,18 @@
 Camel DSL for FS2
 -----------------
 
-[Apache Camel endpoints](http://camel.apache.org/components.html) can be integrated into [FS2](https://github.com/functional-streams-for-scala/fs2) applications with a DSL that is provided by the `streamz-camel-fs2` artifact.
+[Apache Camel endpoints](http://camel.apache.org/components.html) can be integrated into [FS2](https://github.com/functional-streams-for-scala/fs2) applications with a [DSL](#dsl).
+ 
+### Dependencies
+
+The DSL is provided by the `streamz-camel-fs2` artifact which is available for Scala 2.11 and 2.12:
+
+    resolvers += "krasserm at bintray" at "http://dl.bintray.com/krasserm/maven"
+
+    libraryDependencies += "com.github.krasserm" %% "streamz-camel-fs2" % "0.7"
+
+<a name="dsl"></a>
+### DSL
 
 The DSL can be imported with:
 
@@ -33,7 +44,7 @@ implicit val streamContext: StreamContext = StreamContext(camelContext)
 
 After usage, a `StreamContext` should be stopped with `streamContext.stop()`. 
 
-#### Consuming from an endpoint
+#### Receiving in-only message exchanges from an endpoint
 
 An FS2 stream that emits messages consumed from a Camel endpoint can be created with `receive`. Endpoints are referenced by their [endpoint URI](http://camel.apache.org/uris.html). For example,
 
@@ -51,7 +62,13 @@ val s1b: Stream[Task, String] = receiveBody[String]("seda:q1")
 
 This is equivalent to `receive[String]("seda:q1").map(_.body)`.
 
-#### Sending to an endpoint
+`receive` and `receiveBody` can only be used with endpoints that create [in-only message exchanges](http://camel.apache.org/exchange-pattern.html). 
+
+#### Receiving in-out message exchanges from an endpoint
+
+...
+
+#### Sending in-only message exchanges to an endpoint
 
 For sending a `StreamMessage` to a Camel endpoint, the `send` combinator should be used:
 
@@ -69,20 +86,20 @@ val s2b: Stream[Task, String] = s1b.send("seda:q2")
 
 If `A` is not a `StreamMessage`, `send` automatically wraps the message into a `StreamMessage[A]` before sending it to the endpoint and continues the stream with the unwrapped `A`.
 
-#### Requesting from an endpoint
+#### Sending in-out message exchanges to an endpoint
 
-For requesting a reply from an endpoint to an input `StreamMessage`, the `request` combinator should be used:
-
-```scala
-val s3: Stream[Task, StreamMessage[Int]] = s2.request[Int]("bean:service?method=weight")
-```
-
-This initiates an in-out message exchange with the endpoint and continues the stream with the output `StreamMessage`. Here, a [Bean endpoint](https://camel.apache.org/bean.html) is used to call the `weight(String): Int` method on an object that is registered in the `CamelContext` under the name `service`. The input message body is used as `weight` call argument, the output message body is assigned the return value. The `receive` type parameter (`Int`) specifies the expected output value type. The output message body can also be converted to another type provided that an appropriate Camel type converter is available (`Double`, for example). 
-
-The `request` combinator is not only available for streams of type `Stream[Task, StreamMessage[A]]` but more generally for any stream of type `Stream[Task, A]`:
+For sending a request `StreamMessage` to an endpoint and obtaining a reply, the `sendRequest` combinator should be used:
 
 ```scala
-val s3b: Stream[Task, Int] = s2b.request[Int]("bean:service?method=weight")
+val s3: Stream[Task, StreamMessage[Int]] = s2.sendRequest[Int]("bean:service?method=weight")
 ```
 
-If `A` is not a `StreamMessage`, `request` automatically wraps the message into a `StreamMessage[A]` before sending it to the endpoint and continues the stream with the unwrapped message body `B` of the output `StreamMessage[B]`.
+This initiates an in-out message exchange with the endpoint and continues the stream with the output `StreamMessage`. Here, a [Bean endpoint](https://camel.apache.org/bean.html) is used to call the `weight(String): Int` method on an object that is registered in the `CamelContext` under the name `service`. The input message body is used as `weight` call argument, the output message body is assigned the return value. The `sendRequest` type parameter (`Int`) specifies the expected output value type. The output message body can also be converted to another type provided that an appropriate Camel type converter is available (`Double`, for example). 
+
+The `sendRequest` combinator is not only available for streams of type `Stream[Task, StreamMessage[A]]` but more generally for any stream of type `Stream[Task, A]`:
+
+```scala
+val s3b: Stream[Task, Int] = s2b.sendRequest[Int]("bean:service?method=weight")
+```
+
+If `A` is not a `StreamMessage`, `sendRequest` automatically wraps the message into a `StreamMessage[A]` before sending it to the endpoint and continues the stream with the unwrapped message body `B` of the output `StreamMessage[B]`.

--- a/streamz-camel-fs2/src/main/scala/streamz/camel/fs2/dsl/package.scala
+++ b/streamz-camel-fs2/src/main/scala/streamz/camel/fs2/dsl/package.scala
@@ -38,10 +38,10 @@ package object dsl {
       self.through(dsl.send[A](uri))
 
     /**
-     * @see [[dsl.request]]
+     * @see [[dsl.sendRequest]]
      */
-    def request[B](uri: String)(implicit context: StreamContext, strategy: Strategy, tag: ClassTag[B]): Stream[Task, StreamMessage[B]] =
-      self.through(dsl.request[A, B](uri))
+    def sendRequest[B](uri: String)(implicit context: StreamContext, strategy: Strategy, tag: ClassTag[B]): Stream[Task, StreamMessage[B]] =
+      self.through(dsl.sendRequest[A, B](uri))
   }
 
   /**
@@ -55,10 +55,10 @@ package object dsl {
       self.through(dsl.sendBody[A](uri))
 
     /**
-     * @see [[dsl.requestBody]]
+     * @see [[dsl.sendRequestBody]]
      */
-    def request[B](uri: String)(implicit context: StreamContext, strategy: Strategy, tag: ClassTag[B]): Stream[Task, B] =
-      self.through(dsl.requestBody[A, B](uri))
+    def sendRequest[B](uri: String)(implicit context: StreamContext, strategy: Strategy, tag: ClassTag[B]): Stream[Task, B] =
+      self.through(dsl.sendRequestBody[A, B](uri))
   }
 
   /**
@@ -121,7 +121,7 @@ package object dsl {
    * @param uri Camel endpoint URI.
    * @throws TypeConversionException if type conversion fails.
    */
-  def request[A, B](uri: String)(implicit context: StreamContext, strategy: Strategy, tag: ClassTag[B]): Pipe[Task, StreamMessage[A], StreamMessage[B]] =
+  def sendRequest[A, B](uri: String)(implicit context: StreamContext, strategy: Strategy, tag: ClassTag[B]): Pipe[Task, StreamMessage[A], StreamMessage[B]] =
     produce[A, B](uri, ExchangePattern.InOut, (_, exchange) => StreamMessage.from[B](exchange.getOut))
 
   /**
@@ -133,8 +133,8 @@ package object dsl {
    * @param uri Camel endpoint URI.
    * @throws TypeConversionException if type conversion fails.
    */
-  def requestBody[A, B](uri: String)(implicit context: StreamContext, strategy: Strategy, tag: ClassTag[B]): Pipe[Task, A, B] =
-    s => s.map(StreamMessage(_)).through(request[A, B](uri)).map(_.body)
+  def sendRequestBody[A, B](uri: String)(implicit context: StreamContext, strategy: Strategy, tag: ClassTag[B]): Pipe[Task, A, B] =
+    s => s.map(StreamMessage(_)).through(sendRequest[A, B](uri)).map(_.body)
 
   private def consume[A](uri: String)(implicit context: StreamContext, strategy: Strategy, tag: ClassTag[A]): Stream[Task, StreamMessage[A]] = {
     import context._

--- a/streamz-converter/README.md
+++ b/streamz-converter/README.md
@@ -1,7 +1,13 @@
 Stream converters
 -----------------
 
-Stream converters convert Akka Stream `Source`s, `Flow`s and `Sink`s to FS2 `Stream`s, `Pipe`s and `Sink`s, respectively, and vice versa. They are provided by the `streamz-converter` artifact and can be imported with: 
+Stream converters convert Akka Stream `Source`s, `Flow`s and `Sink`s to FS2 `Stream`s, `Pipe`s and `Sink`s, respectively, and vice versa. They are provided by the 
+
+    resolvers += "krasserm at bintray" at "http://dl.bintray.com/krasserm/maven"
+
+    libraryDependencies += "com.github.krasserm" %% "streamz-converter" % "0.7"
+
+artifact and can be imported with: 
 
 ```scala
 import streamz.converter._

--- a/streamz-converter/src/test/resources/reference.conf
+++ b/streamz-converter/src/test/resources/reference.conf
@@ -1,2 +1,1 @@
-akka.log-dead-letters-during-shutdown = off
 akka.stream.materializer.debug.fuzzing-mode = on

--- a/streamz-examples/README.md
+++ b/streamz-examples/README.md
@@ -91,7 +91,7 @@ public class JExample extends JExampleContext {
                 receiveBody(fileEndpointUri, String.class).mapConcat(s -> asList(s.split("\\r\\n|\\n|\\r")));
 
         Source<String, NotUsed> linePrefixSource =
-                Source.range(1, Integer.MAX_VALUE).via(requestBody(serviceEndpointUri, String.class));
+                Source.range(1, Integer.MAX_VALUE).via(sendRequestBody(serviceEndpointUri, String.class));
 
         Source<String, NotUsed> stream =
                 tcpLineSource
@@ -164,7 +164,7 @@ object Example extends ExampleContext with App {
     receiveBody[String](fileEndpointUri).mapConcat(_.lines.to[Iterable])
 
   val linePrefixSource: Source[String, NotUsed] =
-    Source.fromIterator(() => Iterator.from(1)).request[String](serviceEndpointUri)
+    Source.fromIterator(() => Iterator.from(1)).sendRequest[String](serviceEndpointUri)
 
   val stream: Source[String, NotUsed] =
     tcpLineSource
@@ -198,7 +198,7 @@ object Example extends ExampleContext with App {
     receiveBody[String](fileEndpointUri).through(text.lines)
 
   val linePrefixStream: Stream[Task, String] =
-    Stream.iterate(1)(_ + 1).request[String](serviceEndpointUri)
+    Stream.iterate(1)(_ + 1).sendRequest[String](serviceEndpointUri)
 
   val stream: Stream[Task, String] =
     tcpLineStream

--- a/streamz-examples/src/main/java/streamz/examples/camel/akka/JExample.java
+++ b/streamz-examples/src/main/java/streamz/examples/camel/akka/JExample.java
@@ -41,7 +41,7 @@ public class JExample extends JExampleContext {
                 receiveBody(fileEndpointUri, String.class).mapConcat(s -> asList(s.split("\\r\\n|\\n|\\r")));
 
         Source<String, NotUsed> linePrefixSource =
-                Source.range(1, Integer.MAX_VALUE).via(requestBody(serviceEndpointUri, String.class));
+                Source.range(1, Integer.MAX_VALUE).via(sendRequestBody(serviceEndpointUri, String.class));
 
         Source<String, NotUsed> stream =
                 tcpLineSource

--- a/streamz-examples/src/main/java/streamz/examples/camel/akka/JGreeter.java
+++ b/streamz-examples/src/main/java/streamz/examples/camel/akka/JGreeter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014 - 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package streamz.examples.camel.akka;
+
+import akka.NotUsed;
+import akka.actor.ActorSystem;
+import akka.stream.ActorMaterializer;
+import akka.stream.javadsl.Flow;
+import streamz.camel.StreamContext;
+import streamz.camel.akka.javadsl.JavaDsl;
+
+public class JGreeter implements JavaDsl, Runnable {
+    private ActorSystem actorSystem;
+    private ActorMaterializer actorMaterializer;
+    private StreamContext streamContext;
+
+    public JGreeter() {
+        this.actorSystem = ActorSystem.create("example");
+        this.actorMaterializer = ActorMaterializer.create(actorSystem);
+        this.streamContext = StreamContext.create();
+    }
+
+    @Override
+    public StreamContext streamContext() {
+        return streamContext;
+    }
+
+    @Override
+    public void run() {
+        Flow<String, String, NotUsed> tcp = receiveRequestBody("netty4:tcp://localhost:5150?textline=true", String.class);
+        tcp.map(line -> "hello " + line).join(reply()).run(actorMaterializer);
+    }
+
+    public static void main(String... args) throws Exception {
+        new JGreeter().run();
+    }
+}

--- a/streamz-examples/src/main/scala/streamz/examples/camel/fs2/Example.scala
+++ b/streamz-examples/src/main/scala/streamz/examples/camel/fs2/Example.scala
@@ -32,7 +32,7 @@ object Example extends ExampleContext with App {
     receiveBody[String](fileEndpointUri).through(text.lines)
 
   val linePrefixStream: Stream[Task, String] =
-    Stream.iterate(1)(_ + 1).request[String](serviceEndpointUri)
+    Stream.iterate(1)(_ + 1).sendRequest[String](serviceEndpointUri)
 
   val stream: Stream[Task, String] =
     tcpLineStream

--- a/streamz-examples/src/main/scala/streamz/examples/camel/fs2/Snippets.scala
+++ b/streamz-examples/src/main/scala/streamz/examples/camel/fs2/Snippets.scala
@@ -33,7 +33,7 @@ object Snippets {
       // in-only message exchange with endpoint and continue stream with in-message
       .send("seda:q2")
       // in-out message exchange with endpoint and continue stream with out-message
-      .request[Int]("bean:service?method=weight")
+      .sendRequest[Int]("bean:service?method=weight")
 
   // create task from stream
   val t: Task[Unit] = s.run
@@ -43,9 +43,9 @@ object Snippets {
 
   val s1: Stream[Task, StreamMessage[String]] = receive[String]("seda:q1")
   val s2: Stream[Task, StreamMessage[String]] = s1.send("seda:q2")
-  val s3: Stream[Task, StreamMessage[Int]] = s2.request[Int]("bean:service?method=weight")
+  val s3: Stream[Task, StreamMessage[Int]] = s2.sendRequest[Int]("bean:service?method=weight")
 
   val s1b: Stream[Task, String] = receiveBody[String]("seda:q1")
   val s2b: Stream[Task, String] = s1b.send("seda:q2")
-  val s3b: Stream[Task, Int] = s2b.request[Int]("bean:service?method=weight")
+  val s3b: Stream[Task, Int] = s2b.sendRequest[Int]("bean:service?method=weight")
 }


### PR DESCRIPTION
- receiveRequest, receiveRequestBody and reply DSL elements added
- enable fuzzing mode for testing
- closes #28

Breaking changes:

- request method renamed to sendRequest
- requestBody method renamed to sendRequestBody