### PR TITLE
Replace ActorPublisher with GraphStage in streamz-camel-akka

### DIFF
--- a/streamz-camel-akka/src/main/scala/streamz/camel/akka/scaladsl/package.scala
+++ b/streamz-camel-akka/src/main/scala/streamz/camel/akka/scaladsl/package.scala
@@ -212,7 +212,7 @@ package object scaladsl {
     Flow[A].map(StreamMessage(_)).via(sendRequest[A, B](uri, parallelism)).map(_.body)
 
   private def consumeInOnly[A](uri: String)(implicit streamContext: StreamContext, tag: ClassTag[A]): Source[StreamMessage[A], NotUsed] =
-    Source.actorPublisher[StreamMessage[A]](EndpointConsumer.props[A](uri)).mapMaterializedValue(_ => NotUsed)
+    Source.fromGraph(new EndpointConsumer[A](uri))
 
   private def consumeInOut[A, B](uri: String, capacity: Int)(implicit streamContext: StreamContext, tag: ClassTag[B]): Flow[StreamMessage[A], StreamMessage[B], NotUsed] =
     Flow.fromGraph(new EndpointConsumerReplier[A, B](uri, capacity))


### PR DESCRIPTION
@krasserm: This PR pertains to #32 and replaces the deprecated `ActorPublisher` with `GraphStage`. Note that I made this change only in the **streamz-camel-akka** subproject; I didn't replace the use of `ActorPublisher` in **streamz-converter**.