### PR TITLE
Update sbt and dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_script:
 language:
   - scala
 scala:
-  - 2.11.11
-  - 2.12.2
+  - 2.11.12
+  - 2.12.4
 jdk:
   - oraclejdk8

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,7 @@
 import com.typesafe.sbt.SbtScalariform
 import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 
-import de.heikoseeberger.sbtheader.license.Apache2_0
-
 import scalariform.formatter.preferences._
-
-import UnidocKeys._
 
 // ---------------------------------------------------------------------------
 //  Main settings
@@ -17,9 +13,9 @@ organization in ThisBuild := "com.github.krasserm"
 
 version in ThisBuild := "0.9-SNAPSHOT"
 
-crossScalaVersions in ThisBuild := Seq("2.11.11", "2.12.2")
+crossScalaVersions in ThisBuild := Seq("2.11.12", "2.12.4")
 
-scalaVersion in ThisBuild := "2.12.2"
+scalaVersion in ThisBuild := "2.12.4"
 
 scalacOptions in ThisBuild ++= Seq("-feature", "-language:higherKinds", "-language:implicitConversions", "-deprecation")
 
@@ -29,23 +25,20 @@ libraryDependencies in ThisBuild += "org.scalatest" %% "scalatest" % Version.Sca
 //  Code formatter settings
 // ---------------------------------------------------------------------------
 
-SbtScalariform.scalariformSettings
-
 ScalariformKeys.preferences := ScalariformKeys.preferences.value
   .setPreference(AlignSingleLineCaseStatements, true)
   .setPreference(DanglingCloseParenthesis, Preserve)
-  .setPreference(DoubleIndentClassDeclaration, false)
+  .setPreference(DoubleIndentConstructorArguments, false)
 
 // ---------------------------------------------------------------------------
 //  License header settings
 // ---------------------------------------------------------------------------
 
-lazy val header = Apache2_0("2014 - 2017", "the original author or authors.")
+lazy val header = HeaderLicense.ALv2("2014 - 2017", "the original author or authors.")
 
-lazy val headerSettings = Seq(headers := Map(
-  "scala" -> header,
-  "java" -> header
-))
+lazy val headerSettings = Seq(
+  headerLicense := Some(header)
+)
 
 // ---------------------------------------------------------------------------
 //  Projects
@@ -53,8 +46,8 @@ lazy val headerSettings = Seq(headers := Map(
 
 lazy val root = project.in(file("."))
   .aggregate(camelContext, camelAkka, camelFs2, converter, examples)
-  .settings(unidocSettings: _*)
   .settings(unidocProjectFilter in (ScalaUnidoc, unidoc) := inAnyProject -- inProjects(examples))
+  .enablePlugins(ScalaUnidocPlugin)
 
 lazy val camelContext = project.in(file("streamz-camel-context"))
   .enablePlugins(AutomateHeaderPlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ ScalariformKeys.preferences := ScalariformKeys.preferences.value
 //  License header settings
 // ---------------------------------------------------------------------------
 
-lazy val header = HeaderLicense.ALv2("2014 - 2017", "the original author or authors.")
+lazy val header = HeaderLicense.ALv2("2014 - 2018", "the original author or authors.")
 
 lazy val headerSettings = Seq(
   headerLicense := Some(header)

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,8 +1,8 @@
 object Version {
-  val Akka = "2.5.8"
-  val Camel = "2.20.1"
-  val Fs2 = "0.10.0-M10"
-  val Log4j = "2.5"
+  val Akka = "2.5.9"
+  val Camel = "2.20.2"
+  val Fs2 = "0.10.0"
+  val Log4j = "2.10.0"
   val JUnitInterface = "0.11"
-  val Scalatest = "3.0.1"
+  val Scalatest = "3.0.5"
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=1.1.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
-addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.3")
+addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.1")
 
-addSbtPlugin("de.heikoseeberger" % "sbt-header" % "1.6.0")
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "4.1.0")
 
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")

--- a/streamz-camel-akka/src/main/java/streamz/camel/akka/javadsl/JavaDsl.java
+++ b/streamz-camel-akka/src/main/java/streamz/camel/akka/javadsl/JavaDsl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2017 the original author or authors.
+ * Copyright 2014 - 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-camel-akka/src/main/scala/streamz/camel/akka/EndpointConsumer.scala
+++ b/streamz-camel-akka/src/main/scala/streamz/camel/akka/EndpointConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2017 the original author or authors.
+ * Copyright 2014 - 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-camel-akka/src/main/scala/streamz/camel/akka/EndpointConsumer.scala
+++ b/streamz-camel-akka/src/main/scala/streamz/camel/akka/EndpointConsumer.scala
@@ -26,7 +26,7 @@ import scala.reflect.ClassTag
 import scala.util.{ Failure, Success, Try }
 
 private[akka] class EndpointConsumer[A](uri: String)(implicit streamContext: StreamContext, tag: ClassTag[A])
-    extends GraphStage[SourceShape[StreamMessage[A]]] {
+  extends GraphStage[SourceShape[StreamMessage[A]]] {
 
   private implicit val ec: ExecutionContext =
     ExecutionContext.fromExecutorService(streamContext.executorService)

--- a/streamz-camel-akka/src/main/scala/streamz/camel/akka/EndpointConsumerReplier.scala
+++ b/streamz-camel-akka/src/main/scala/streamz/camel/akka/EndpointConsumerReplier.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2017 the original author or authors.
+ * Copyright 2014 - 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-camel-akka/src/main/scala/streamz/camel/akka/EndpointConsumerReplier.scala
+++ b/streamz-camel-akka/src/main/scala/streamz/camel/akka/EndpointConsumerReplier.scala
@@ -46,7 +46,7 @@ private class AsyncExchangeProcessor(capacity: Int) extends AsyncProcessor {
 }
 
 private[akka] class EndpointConsumerReplier[A, B](uri: String, capacity: Int)(implicit streamContext: StreamContext, tag: ClassTag[B])
-    extends GraphStage[FlowShape[StreamMessage[A], StreamMessage[B]]] {
+  extends GraphStage[FlowShape[StreamMessage[A], StreamMessage[B]]] {
 
   private implicit val ec: ExecutionContext =
     ExecutionContext.fromExecutorService(streamContext.executorService)

--- a/streamz-camel-akka/src/main/scala/streamz/camel/akka/javadsl/JavaDslDef.scala
+++ b/streamz-camel-akka/src/main/scala/streamz/camel/akka/javadsl/JavaDslDef.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2017 the original author or authors.
+ * Copyright 2014 - 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-camel-akka/src/main/scala/streamz/camel/akka/scaladsl/package.scala
+++ b/streamz-camel-akka/src/main/scala/streamz/camel/akka/scaladsl/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2017 the original author or authors.
+ * Copyright 2014 - 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-camel-akka/src/test/java/streamz/camel/akka/javadsl/JavaDslTest.java
+++ b/streamz-camel-akka/src/test/java/streamz/camel/akka/javadsl/JavaDslTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2017 the original author or authors.
+ * Copyright 2014 - 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-camel-akka/src/test/java/streamz/camel/akka/javadsl/JavaDslTestService.java
+++ b/streamz-camel-akka/src/test/java/streamz/camel/akka/javadsl/JavaDslTestService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2017 the original author or authors.
+ * Copyright 2014 - 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-camel-akka/src/test/scala/streamz/camel/akka/EndpointConsumerReplierSpec.scala
+++ b/streamz-camel-akka/src/test/scala/streamz/camel/akka/EndpointConsumerReplierSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2017 the original author or authors.
+ * Copyright 2014 - 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-camel-akka/src/test/scala/streamz/camel/akka/EndpointConsumerSpec.scala
+++ b/streamz-camel-akka/src/test/scala/streamz/camel/akka/EndpointConsumerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2017 the original author or authors.
+ * Copyright 2014 - 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-camel-akka/src/test/scala/streamz/camel/akka/scaladsl/ScalaDslSpec.scala
+++ b/streamz-camel-akka/src/test/scala/streamz/camel/akka/scaladsl/ScalaDslSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2017 the original author or authors.
+ * Copyright 2014 - 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-camel-context/src/main/scala/streamz/camel/StreamContext.scala
+++ b/streamz-camel-context/src/main/scala/streamz/camel/StreamContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2017 the original author or authors.
+ * Copyright 2014 - 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-camel-context/src/main/scala/streamz/camel/StreamMessage.scala
+++ b/streamz-camel-context/src/main/scala/streamz/camel/StreamMessage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2017 the original author or authors.
+ * Copyright 2014 - 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-camel-context/src/test/scala/streamz/camel/StreamMessageSpec.scala
+++ b/streamz-camel-context/src/test/scala/streamz/camel/StreamMessageSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2017 the original author or authors.
+ * Copyright 2014 - 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-camel-fs2/src/main/scala/streamz/camel/fs2/dsl/package.scala
+++ b/streamz-camel-fs2/src/main/scala/streamz/camel/fs2/dsl/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2017 the original author or authors.
+ * Copyright 2014 - 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-camel-fs2/src/test/scala/streamz/camel/fs2/dsl/DslSpec.scala
+++ b/streamz-camel-fs2/src/test/scala/streamz/camel/fs2/dsl/DslSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2017 the original author or authors.
+ * Copyright 2014 - 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-camel-fs2/src/test/scala/streamz/camel/fs2/dsl/DslSpec.scala
+++ b/streamz-camel-fs2/src/test/scala/streamz/camel/fs2/dsl/DslSpec.scala
@@ -57,17 +57,17 @@ class DslSpec extends WordSpec with Matchers with BeforeAndAfterAll {
   "receive" must {
     "consume from an endpoint" in {
       1 to 3 foreach { i => producerTemplate.sendBody("seda:q1", i) }
-      receiveBody[Int]("seda:q1").take(3).runLog.unsafeRunSync() should be(Seq(1, 2, 3))
+      receiveBody[Int]("seda:q1").take(3).compile.toList.unsafeRunSync() should be(Seq(1, 2, 3))
     }
     "complete with an error if type conversion fails" in {
       producerTemplate.sendBody("seda:q2", "a")
-      intercept[TypeConversionException](receiveBody[Int]("seda:q2").run.unsafeRunSync())
+      intercept[TypeConversionException](receiveBody[Int]("seda:q2").compile.drain.unsafeRunSync())
     }
   }
 
   "send" must {
     "send a message to an endpoint and continue with the sent message" in {
-      val result = Stream(1, 2, 3).send("seda:q3").take(3).runLog.unsafeToFuture()
+      val result = Stream(1, 2, 3).send("seda:q3").take(3).compile.toList.unsafeToFuture()
       1 to 3 foreach { i => consumerTemplate.receiveBody("seda:q3") should be(i) }
       Await.result(result, 3.seconds) should be(Seq(1, 2, 3))
     }
@@ -75,13 +75,13 @@ class DslSpec extends WordSpec with Matchers with BeforeAndAfterAll {
 
   "sendRequest" must {
     "send a request message to an endpoint and continue with the response message" in {
-      Stream(1, 2, 3).sendRequest[Int]("bean:service?method=plusOne").runLog.unsafeRunSync() should be(Seq(2, 3, 4))
+      Stream(1, 2, 3).sendRequest[Int]("bean:service?method=plusOne").compile.toList.unsafeRunSync() should be(Seq(2, 3, 4))
     }
     "convert response message types using a Camel type converter" in {
-      Stream(1, 2, 3).sendRequest[String]("bean:service?method=plusOne").runLog.unsafeRunSync() should be(Seq("2", "3", "4"))
+      Stream(1, 2, 3).sendRequest[String]("bean:service?method=plusOne").compile.toList.unsafeRunSync() should be(Seq("2", "3", "4"))
     }
     "complete with an error if the request fails" in {
-      intercept[Exception](Stream(-1, 2, 3).sendRequest[Int]("bean:service?method=plusOne").run.unsafeRunSync()).getMessage should be("test")
+      intercept[Exception](Stream(-1, 2, 3).sendRequest[Int]("bean:service?method=plusOne").compile.drain.unsafeRunSync()).getMessage should be("test")
     }
   }
 }

--- a/streamz-converter/src/main/scala/streamz/converter/AkkaStreamPublisher.scala
+++ b/streamz-converter/src/main/scala/streamz/converter/AkkaStreamPublisher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2017 the original author or authors.
+ * Copyright 2014 - 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-converter/src/main/scala/streamz/converter/AkkaStreamSubscriber.scala
+++ b/streamz-converter/src/main/scala/streamz/converter/AkkaStreamSubscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2017 the original author or authors.
+ * Copyright 2014 - 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-converter/src/main/scala/streamz/converter/Converter.scala
+++ b/streamz-converter/src/main/scala/streamz/converter/Converter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2017 the original author or authors.
+ * Copyright 2014 - 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-converter/src/main/scala/streamz/converter/Converter.scala
+++ b/streamz-converter/src/main/scala/streamz/converter/Converter.scala
@@ -45,8 +45,7 @@ trait Converter {
         val (mat, subscriber) = AkkaSource.fromGraph(source).toMat(AkkaSink.actorSubscriber[A](AkkaStreamSubscriber.props[A]))(Keep.both).run()
         onMaterialization(mat)
         subscriber
-      }
-    )(subscriberStream[A], _ => IO.pure(()))
+      })(subscriberStream[A], _ => IO.pure(()))
 
   /**
    * Converts an Akka Stream [[Graph]] of [[SinkShape]] to an FS2 [[Sink]]. The [[Graph]] is materialized when
@@ -58,8 +57,7 @@ trait Converter {
         val (publisher, mat) = AkkaSource.actorPublisher[A](AkkaStreamPublisher.props[A]).toMat(sink)(Keep.both).run()
         onMaterialization(mat)
         publisher
-      }
-    )(publisherStream[A](_, s), _ => IO.pure(()))
+      })(publisherStream[A](_, s), _ => IO.pure(()))
   }
 
   /**
@@ -74,8 +72,7 @@ trait Converter {
         val ((publisher, mat), subscriber) = src.viaMat(flow)(Keep.both).toMat(snk)(Keep.both).run()
         onMaterialization(mat)
         (publisher, subscriber)
-      }
-    )(ps => transformerStream[A, B](ps._2, ps._1, s), _ => IO.pure(()))
+      })(ps => transformerStream[A, B](ps._2, ps._1, s), _ => IO.pure(()))
   }
 
   /**

--- a/streamz-converter/src/main/scala/streamz/converter/package.scala
+++ b/streamz-converter/src/main/scala/streamz/converter/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2017 the original author or authors.
+ * Copyright 2014 - 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-converter/src/test/scala/streamz/converter/AkkaStreamPublisherSpec.scala
+++ b/streamz-converter/src/test/scala/streamz/converter/AkkaStreamPublisherSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2017 the original author or authors.
+ * Copyright 2014 - 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-converter/src/test/scala/streamz/converter/AkkaStreamSubscriberSpec.scala
+++ b/streamz-converter/src/test/scala/streamz/converter/AkkaStreamSubscriberSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2017 the original author or authors.
+ * Copyright 2014 - 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-converter/src/test/scala/streamz/converter/ConverterSpec.scala
+++ b/streamz-converter/src/test/scala/streamz/converter/ConverterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2017 the original author or authors.
+ * Copyright 2014 - 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-examples/src/main/java/streamz/examples/camel/akka/JExample.java
+++ b/streamz-examples/src/main/java/streamz/examples/camel/akka/JExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2017 the original author or authors.
+ * Copyright 2014 - 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-examples/src/main/java/streamz/examples/camel/akka/JExampleContext.java
+++ b/streamz-examples/src/main/java/streamz/examples/camel/akka/JExampleContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2017 the original author or authors.
+ * Copyright 2014 - 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-examples/src/main/java/streamz/examples/camel/akka/JExampleService.java
+++ b/streamz-examples/src/main/java/streamz/examples/camel/akka/JExampleService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2017 the original author or authors.
+ * Copyright 2014 - 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-examples/src/main/java/streamz/examples/camel/akka/JGreeter.java
+++ b/streamz-examples/src/main/java/streamz/examples/camel/akka/JGreeter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2017 the original author or authors.
+ * Copyright 2014 - 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-examples/src/main/java/streamz/examples/camel/akka/JSnippets.java
+++ b/streamz-examples/src/main/java/streamz/examples/camel/akka/JSnippets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2017 the original author or authors.
+ * Copyright 2014 - 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-examples/src/main/scala/streamz/examples/camel/ExampleContext.scala
+++ b/streamz-examples/src/main/scala/streamz/examples/camel/ExampleContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2017 the original author or authors.
+ * Copyright 2014 - 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-examples/src/main/scala/streamz/examples/camel/akka/Example.scala
+++ b/streamz-examples/src/main/scala/streamz/examples/camel/akka/Example.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2017 the original author or authors.
+ * Copyright 2014 - 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-examples/src/main/scala/streamz/examples/camel/akka/Greeter.scala
+++ b/streamz-examples/src/main/scala/streamz/examples/camel/akka/Greeter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2017 the original author or authors.
+ * Copyright 2014 - 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-examples/src/main/scala/streamz/examples/camel/akka/Snippets.scala
+++ b/streamz-examples/src/main/scala/streamz/examples/camel/akka/Snippets.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2017 the original author or authors.
+ * Copyright 2014 - 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-examples/src/main/scala/streamz/examples/camel/fs2/Example.scala
+++ b/streamz-examples/src/main/scala/streamz/examples/camel/fs2/Example.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2017 the original author or authors.
+ * Copyright 2014 - 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-examples/src/main/scala/streamz/examples/camel/fs2/Snippets.scala
+++ b/streamz-examples/src/main/scala/streamz/examples/camel/fs2/Snippets.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2017 the original author or authors.
+ * Copyright 2014 - 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-examples/src/main/scala/streamz/examples/converter/Example.scala
+++ b/streamz-examples/src/main/scala/streamz/examples/converter/Example.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2017 the original author or authors.
+ * Copyright 2014 - 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Updated to sbt 1.1.0 and fs2 0.10.0. This PR doesn't include converter migration to `GraphStage`.