### PR TITLE
Localize streamz-converter dependencies to module

### DIFF
--- a/streamz-converter/build.sbt
+++ b/streamz-converter/build.sbt
@@ -1,6 +1,6 @@
 name := "streamz-converter"
 
-libraryDependencies in ThisBuild ++= Seq(
+libraryDependencies ++= Seq(
   "co.fs2"            %% "fs2-core"            % Version.Fs2,
   "com.typesafe.akka" %% "akka-stream"         % Version.Akka,
   "com.typesafe.akka" %% "akka-stream-testkit" % Version.Akka % "test",


### PR DESCRIPTION
Previously, the `in ThisBuild` marker on the `libraryDependencies`
of `streamz-converter` was making all of those dependencies into
dependencies of all build modules. This turned FS2 and Cats into
dependencies of `streamz-camel-akka`, which was not desired.

This fixes #48.