### PR TITLE
#56: Add Typesafe Config to allow override of default timeout value

### DIFF
--- a/project/Version.scala
+++ b/project/Version.scala
@@ -5,4 +5,5 @@ object Version {
   val Log4j = "2.10.0"
   val JUnitInterface = "0.11"
   val Scalatest = "3.0.5"
+  val Config = "1.3.3"
 }

--- a/streamz-camel-akka/README.md
+++ b/streamz-camel-akka/README.md
@@ -11,6 +11,12 @@ The DSL is provided by the `streamz-camel-akka` artifact which is available for 
 
     libraryDependencies += "com.github.krasserm" %% "streamz-camel-akka" % "0.10-M1"
 
+### Configuration
+
+The consumer receive timeout on Camel endpoints defaults to 500 ms. If you need to change that, you can do so in `application.conf`:
+
+    streamz.camel.consumer.receive.timeout = 10s
+
 <a name="scala-dsl"></a>
 ### Scala DSL
 

--- a/streamz-camel-akka/src/main/scala/streamz/camel/akka/EndpointConsumer.scala
+++ b/streamz-camel-akka/src/main/scala/streamz/camel/akka/EndpointConsumer.scala
@@ -16,6 +16,8 @@
 
 package streamz.camel.akka
 
+import java.util.concurrent.TimeUnit
+
 import akka.stream._
 import akka.stream.stage._
 import org.apache.camel._
@@ -30,6 +32,8 @@ private[akka] class EndpointConsumer[A](uri: String)(implicit streamContext: Str
 
   private implicit val ec: ExecutionContext =
     ExecutionContext.fromExecutorService(streamContext.executorService)
+
+  private val timeout: Long = streamContext.config.getDuration("streamz.camel.consumer.receive.timeout", TimeUnit.MILLISECONDS)
 
   val out: Outlet[StreamMessage[A]] =
     Outlet("EndpointConsumer.out")
@@ -49,7 +53,7 @@ private[akka] class EndpointConsumer[A](uri: String)(implicit streamContext: Str
       })
 
       private def consumeAsync(): Unit = {
-        Future(consumerTemplate.receive(uri, 500)).foreach(consumedCallback.invoke)
+        Future(consumerTemplate.receive(uri, timeout)).foreach(consumedCallback.invoke)
       }
 
       private def consumed(exchange: Exchange): Unit = {

--- a/streamz-camel-akka/src/main/scala/streamz/camel/akka/EndpointConsumerReplier.scala
+++ b/streamz-camel-akka/src/main/scala/streamz/camel/akka/EndpointConsumerReplier.scala
@@ -51,6 +51,8 @@ private[akka] class EndpointConsumerReplier[A, B](uri: String, capacity: Int)(im
   private implicit val ec: ExecutionContext =
     ExecutionContext.fromExecutorService(streamContext.executorService)
 
+  private val timeout: Long = streamContext.config.getDuration("streamz.camel.consumer.receive.timeout", TimeUnit.MILLISECONDS)
+
   val in: Inlet[StreamMessage[A]] =
     Inlet("EndpointConsumerReplier.in")
 
@@ -88,7 +90,7 @@ private[akka] class EndpointConsumerReplier[A, B](uri: String, capacity: Int)(im
         emittedExchanges.size < capacity
 
       private def consumeAsync(): Unit = {
-        Future(processor.receivedExchanges.poll(500, TimeUnit.MILLISECONDS)).foreach(consumedCallback.invoke)
+        Future(processor.receivedExchanges.poll(timeout, TimeUnit.MILLISECONDS)).foreach(consumedCallback.invoke)
         consuming = true
       }
 

--- a/streamz-camel-context/build.sbt
+++ b/streamz-camel-context/build.sbt
@@ -1,3 +1,5 @@
 name := "streamz-camel-context"
 
-libraryDependencies += "org.apache.camel" % "camel-core" % Version.Camel
+libraryDependencies ++= Seq(
+  "com.typesafe"     % "config"     % Version.Config,
+  "org.apache.camel" % "camel-core" % Version.Camel)

--- a/streamz-camel-context/src/main/resources/reference.conf
+++ b/streamz-camel-context/src/main/resources/reference.conf
@@ -1,0 +1,2 @@
+# Enpoint consumer receive timeout
+streamz.camel.consumer.receive.timeout = 500ms

--- a/streamz-camel-context/src/main/scala/streamz/camel/StreamContext.scala
+++ b/streamz-camel-context/src/main/scala/streamz/camel/StreamContext.scala
@@ -19,6 +19,7 @@ package streamz.camel
 import java.util.concurrent.{ ExecutorService, LinkedBlockingQueue, ThreadPoolExecutor, TimeUnit }
 import java.util.function.Supplier
 
+import com.typesafe.config.{ Config, ConfigFactory }
 import org.apache.camel._
 import org.apache.camel.impl.{ DefaultCamelContext, DefaultExchange }
 
@@ -128,7 +129,11 @@ object StreamContext {
  *                     and stopping the `CamelContext` after stopping this `StreamContext`.
  * @param executorServiceFactory factory for creating this stream context's `executorService`.
  */
-class StreamContext(val camelContext: CamelContext, executorServiceFactory: StreamContext.ExecutorServiceFactory = StreamContext.DefaultExecutorServiceFactory) {
+class StreamContext(
+  val camelContext: CamelContext,
+  executorServiceFactory: StreamContext.ExecutorServiceFactory = StreamContext.DefaultExecutorServiceFactory,
+  val config: Config = ConfigFactory.load()) {
+
   /**
    * Executor service used for running blocking endpoint operations. It is created with `executorServiceFactory`.
    */

--- a/streamz-camel-fs2/README.md
+++ b/streamz-camel-fs2/README.md
@@ -10,6 +10,12 @@ The DSL is provided by the `streamz-camel-fs2` artifact which is available for S
     resolvers += "krasserm at bintray" at "http://dl.bintray.com/krasserm/maven"
 
     libraryDependencies += "com.github.krasserm" %% "streamz-camel-fs2" % "0.10-M1"
+    
+### Configuration
+
+The consumer receive timeout on Camel endpoints defaults to 500 ms. If you need to change that, you can do so in `application.conf`:
+
+    streamz.camel.consumer.receive.timeout = 10s
 
 <a name="dsl"></a>
 ### DSL


### PR DESCRIPTION
As offered here is a PR for #56 using the Typesafe Config. The `reference.conf` provides the default timeout value of 500ms which can be overridden by the users `application.conf`. The `config` is placed in `StreamContext`. There should be no braking changes.