### PR TITLE
Upgrade to cats-effect 2.x, preliminary scala 2.13 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.log
 *.iml
 target/
+.bloop/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language:
   scala
 scala:
   - 2.11.12
-  - 2.12.6
+  - 2.12.8
+  - 2.13.0
 jdk:
   - oraclejdk8

--- a/build.sbt
+++ b/build.sbt
@@ -11,15 +11,16 @@ name := "streamz"
 
 organization in ThisBuild := "com.github.krasserm"
 
-version in ThisBuild := "0.10-SNAPSHOT"
+version in ThisBuild := "0.11-M1"
 
-crossScalaVersions in ThisBuild := Seq("2.11.12", "2.12.6")
+crossScalaVersions in ThisBuild := Seq("2.11.12", "2.12.8", "2.13.0")
 
-scalaVersion in ThisBuild := "2.12.6"
-
-scalacOptions in ThisBuild ++= Seq("-feature", "-language:higherKinds", "-language:implicitConversions", "-deprecation")
+scalaVersion in ThisBuild := "2.12.8"
 
 libraryDependencies in ThisBuild += "org.scalatest" %% "scalatest" % Version.Scalatest % "test"
+
+// No need for `sbt doc` to fail on warnings
+val docSettings = Compile / doc / scalacOptions -= "-Xfatal-warnings"
 
 // ---------------------------------------------------------------------------
 //  Code formatter settings
@@ -34,7 +35,7 @@ ScalariformKeys.preferences := ScalariformKeys.preferences.value
 //  License header settings
 // ---------------------------------------------------------------------------
 
-lazy val header = HeaderLicense.ALv2("2014 - 2018", "the original author or authors.")
+lazy val header = HeaderLicense.ALv2("2014 - 2019", "the original author or authors.")
 
 lazy val headerSettings = Seq(
   headerLicense := Some(header)
@@ -46,28 +47,31 @@ lazy val headerSettings = Seq(
 
 lazy val root = project.in(file("."))
   .aggregate(camelContext, camelAkka, camelFs2, converter, examples)
-  .settings(unidocProjectFilter in (ScalaUnidoc, unidoc) := inAnyProject -- inProjects(examples))
+  .settings(
+    unidocProjectFilter in (ScalaUnidoc, unidoc) := inAnyProject -- inProjects(examples),
+    docSettings
+  )
   .enablePlugins(ScalaUnidocPlugin)
 
 lazy val camelContext = project.in(file("streamz-camel-context"))
   .enablePlugins(AutomateHeaderPlugin)
-  .settings(headerSettings)
+  .settings(headerSettings, docSettings)
 
 lazy val camelAkka = project.in(file("streamz-camel-akka"))
   .enablePlugins(AutomateHeaderPlugin)
-  .settings(headerSettings)
+  .settings(headerSettings, docSettings)
   .dependsOn(camelContext)
 
 lazy val camelFs2 = project.in(file("streamz-camel-fs2"))
   .enablePlugins(AutomateHeaderPlugin)
-  .settings(headerSettings)
+  .settings(headerSettings, docSettings)
   .dependsOn(camelContext)
 
 lazy val converter = project.in(file("streamz-converter"))
   .enablePlugins(AutomateHeaderPlugin)
-  .settings(headerSettings)
+  .settings(headerSettings, docSettings)
 
 lazy val examples = project.in(file("streamz-examples"))
   .enablePlugins(AutomateHeaderPlugin)
-  .settings(headerSettings)
+  .settings(headerSettings, docSettings)
   .dependsOn(camelAkka, camelFs2, converter)

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,9 +1,11 @@
 object Version {
-  val Akka = "2.5.16"
+  val Akka = "2.5.23"
   val Camel = "2.20.2"
-  val Fs2 = "1.0.0"
+  val CatsEffect = "2.0.0-M5"
+  val Fs2 = "1.1.0-M1"
   val Log4j = "2.10.0"
   val JUnitInterface = "0.11"
-  val Scalatest = "3.0.5"
+  val Scalatest = "3.0.8"
   val Config = "1.3.3"
+  val ScalaCollectionCompat = "2.1.1"
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.1
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,3 +3,5 @@ addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.1")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "4.1.0")
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
+
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.7")

--- a/streamz-camel-akka/src/main/java/streamz/camel/akka/javadsl/JavaDsl.java
+++ b/streamz-camel-akka/src/main/java/streamz/camel/akka/javadsl/JavaDsl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2018 the original author or authors.
+ * Copyright 2014 - 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-camel-akka/src/main/scala/streamz/camel/akka/EndpointConsumer.scala
+++ b/streamz-camel-akka/src/main/scala/streamz/camel/akka/EndpointConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2018 the original author or authors.
+ * Copyright 2014 - 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-camel-akka/src/main/scala/streamz/camel/akka/javadsl/JavaDslDef.scala
+++ b/streamz-camel-akka/src/main/scala/streamz/camel/akka/javadsl/JavaDslDef.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2018 the original author or authors.
+ * Copyright 2014 - 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-camel-akka/src/main/scala/streamz/camel/akka/scaladsl/ReplyDsl.scala
+++ b/streamz-camel-akka/src/main/scala/streamz/camel/akka/scaladsl/ReplyDsl.scala
@@ -14,10 +14,20 @@
  * limitations under the License.
  */
 
-package streamz.examples.camel.akka;
+package streamz.camel.akka.scaladsl
 
-public class JExampleService {
-    public String linePrefix(int lineNumber) {
-        return String.format("[%d] ", lineNumber);
-    }
+import akka.stream.scaladsl.{ Flow, Keep, RunnableGraph }
+
+/**
+ * Reply combinator for streams of type `Flow[A, A, M]`.
+ */
+class ReplyDsl[A, M](val self: Flow[A, A, M]) {
+  /**
+   * Pipes the flow's output to its input. Terminal operation on a flow created with [[receiveRequest]]
+   * or [[receiveRequestBody]] whose output type has been transformed to its input type.
+   *
+   * @see [[receiveRequest]]
+   * @see [[receiveRequestBody]]
+   */
+  def reply: RunnableGraph[M] = self.joinMat(Flow[A])(Keep.left)
 }

--- a/streamz-camel-akka/src/main/scala/streamz/camel/akka/scaladsl/SendBodyDsl.scala
+++ b/streamz-camel-akka/src/main/scala/streamz/camel/akka/scaladsl/SendBodyDsl.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014 - 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package streamz.camel.akka.scaladsl
+
+import akka.stream.scaladsl.FlowOps
+import streamz.camel.StreamContext
+import streamz.camel.akka.scaladsl
+
+import scala.reflect.ClassTag
+
+/**
+ * Send combinators for [[streamz.camel.StreamMessage]] body streams of type `FlowOps[A, M]`.
+ */
+class SendBodyDsl[A, M, FO <: FlowOps[A, M]](val self: FO) {
+  /**
+   * @see [[scaladsl.sendBody]]
+   */
+  def send(uri: String, parallelism: Int = 1)(implicit context: StreamContext): self.Repr[A] =
+    self.via(scaladsl.sendBody[A](uri, parallelism))
+
+  /**
+   * @see [[scaladsl.sendRequestBody]]
+   */
+  def sendRequest[B](uri: String, parallelism: Int = 1)(implicit context: StreamContext, tag: ClassTag[B]): self.Repr[B] =
+    self.via(sendRequestBody[A, B](uri, parallelism))
+}

--- a/streamz-camel-akka/src/main/scala/streamz/camel/akka/scaladsl/SendDsl.scala
+++ b/streamz-camel-akka/src/main/scala/streamz/camel/akka/scaladsl/SendDsl.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014 - 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package streamz.camel.akka.scaladsl
+
+import akka.stream.scaladsl.FlowOps
+import streamz.camel.{ StreamContext, StreamMessage }
+import streamz.camel.akka.scaladsl
+
+import scala.reflect.ClassTag
+
+/**
+ * Send combinators for [[StreamMessage]] streams of type `FlowOps[StreamMessage[A], M]`.
+ */
+class SendDsl[A, M, FO <: FlowOps[StreamMessage[A], M]](val self: FO) {
+  /**
+   * @see [[streamz.camel.akka.scaladsl.send]]
+   */
+  def send(uri: String, parallelism: Int = 1)(implicit context: StreamContext): self.Repr[StreamMessage[A]] =
+    self.via(scaladsl.send[A](uri, parallelism))
+
+  /**
+   * @see [[streamz.camel.akka.scaladsl.sendRequest]]
+   */
+  def sendRequest[B](uri: String, parallelism: Int = 1)(implicit context: StreamContext, tag: ClassTag[B]): self.Repr[StreamMessage[B]] =
+    self.via(scaladsl.sendRequest[A, B](uri, parallelism))
+}

--- a/streamz-camel-akka/src/test/java/streamz/camel/akka/javadsl/JavaDslTest.java
+++ b/streamz-camel-akka/src/test/java/streamz/camel/akka/javadsl/JavaDslTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2018 the original author or authors.
+ * Copyright 2014 - 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-camel-akka/src/test/java/streamz/camel/akka/javadsl/JavaDslTestService.java
+++ b/streamz-camel-akka/src/test/java/streamz/camel/akka/javadsl/JavaDslTestService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2018 the original author or authors.
+ * Copyright 2014 - 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-camel-akka/src/test/resources/reference.conf
+++ b/streamz-camel-akka/src/test/resources/reference.conf
@@ -1,3 +1,4 @@
 akka.test.single-expect-default = 10s
 akka.log-dead-letters-during-shutdown = off
 akka.stream.materializer.debug.fuzzing-mode = on
+streamz.camel.consumer.receive.timeout = 500ms

--- a/streamz-camel-akka/src/test/scala/streamz/camel/akka/EndpointConsumerReplierSpec.scala
+++ b/streamz-camel-akka/src/test/scala/streamz/camel/akka/EndpointConsumerReplierSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2018 the original author or authors.
+ * Copyright 2014 - 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import akka.stream.testkit.{ TestPublisher, TestSubscriber }
 import akka.testkit.TestKit
 import org.apache.camel.ExchangePattern
 import org.scalatest.concurrent.Eventually
-import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
+import org.scalatest.{ Assertion, BeforeAndAfterAll, Matchers, WordSpecLike }
 import streamz.camel.{ StreamContext, StreamMessage }
 
 import scala.concurrent.duration._
@@ -42,7 +42,7 @@ class EndpointConsumerReplierSpec extends TestKit(ActorSystem("test")) with Word
     TestKit.shutdownActorSystem(system)
   }
 
-  def awaitEndpointRegistration(uri: String): Unit = {
+  def awaitEndpointRegistration(uri: String): Assertion = {
     eventually { camelContext.getEndpoint(uri) should not be null }
   }
 
@@ -84,7 +84,7 @@ class EndpointConsumerReplierSpec extends TestKit(ActorSystem("test")) with Word
       sub.expectNext().body should be(req(1))
 
       val f3 = producerTemplate.asyncRequestBody(uri, req(2))
-      sub.expectNoMsg(100.millis)
+      sub.expectNoMessage(100.millis)
 
       pub.sendNext(StreamMessage(res.head))
       sub.expectNext().body should be(req(2))
@@ -96,7 +96,7 @@ class EndpointConsumerReplierSpec extends TestKit(ActorSystem("test")) with Word
     }
     "error the stream if a message exchange with the endpoint failed" in {
       val uri = "direct:d3"
-      val (pub, sub) = publisherAndSubscriber[String, String](uri, 3)
+      val (_, sub) = publisherAndSubscriber[String, String](uri, 3)
 
       val exchange = createExchange(StreamMessage("a"), ExchangePattern.InOut)
       exchange.setException(new Exception("boom"))
@@ -107,7 +107,7 @@ class EndpointConsumerReplierSpec extends TestKit(ActorSystem("test")) with Word
     }
     "error the stream if a message exchange is not in-out" in {
       val uri = "direct:d4"
-      val (pub, sub) = publisherAndSubscriber[String, String](uri, 3)
+      val (_, sub) = publisherAndSubscriber[String, String](uri, 3)
 
       val exchange = createExchange(StreamMessage("a"), ExchangePattern.InOnly)
       producerTemplate.asyncSend(uri, exchange)

--- a/streamz-camel-akka/src/test/scala/streamz/camel/akka/EndpointConsumerSpec.scala
+++ b/streamz-camel-akka/src/test/scala/streamz/camel/akka/EndpointConsumerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2018 the original author or authors.
+ * Copyright 2014 - 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,10 +24,9 @@ import akka.stream.testkit.TestSubscriber
 import akka.testkit.TestKit
 import org.apache.camel.ExchangePattern
 import org.scalatest.concurrent.Eventually
-import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
+import org.scalatest.{ Assertion, BeforeAndAfterAll, Matchers, WordSpecLike }
 import streamz.camel.{ StreamContext, StreamMessage }
 
-import scala.concurrent.duration._
 import scala.reflect.ClassTag
 
 class EndpointConsumerSpec extends TestKit(ActorSystem("test")) with WordSpecLike with Matchers with BeforeAndAfterAll with Eventually {
@@ -42,7 +41,7 @@ class EndpointConsumerSpec extends TestKit(ActorSystem("test")) with WordSpecLik
     TestKit.shutdownActorSystem(system)
   }
 
-  def awaitEndpointRegistration(uri: String): Unit = {
+  def awaitEndpointRegistration(uri: String): Assertion = {
     eventually { camelContext.getEndpoint(uri) should not be null }
   }
 
@@ -68,7 +67,7 @@ class EndpointConsumerSpec extends TestKit(ActorSystem("test")) with WordSpecLik
       req.headers("k1") should be("v1")
       req.headers("k2") should be("v2")
 
-      sink.expectNoMsg
+      sink.expectNoMessage(remainingOrDefault)
 
       resf.get.getIn.getBody should be("test")
       resf.get.getIn.getHeader("k1") should be("v1")

--- a/streamz-camel-context/build.sbt
+++ b/streamz-camel-context/build.sbt
@@ -2,4 +2,5 @@ name := "streamz-camel-context"
 
 libraryDependencies ++= Seq(
   "com.typesafe"     % "config"     % Version.Config,
-  "org.apache.camel" % "camel-core" % Version.Camel)
+  "org.apache.camel" % "camel-core" % Version.Camel,
+  "org.scala-lang.modules" %% "scala-collection-compat" % Version.ScalaCollectionCompat)

--- a/streamz-camel-context/src/main/scala/streamz/camel/StreamContext.scala
+++ b/streamz-camel-context/src/main/scala/streamz/camel/StreamContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2018 the original author or authors.
+ * Copyright 2014 - 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-camel-context/src/main/scala/streamz/camel/StreamMessage.scala
+++ b/streamz-camel-context/src/main/scala/streamz/camel/StreamMessage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2018 the original author or authors.
+ * Copyright 2014 - 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,9 @@ package streamz.camel
 import java.util.{ Optional, Map => JMap }
 
 import org.apache.camel.impl.DefaultMessage
-import org.apache.camel.{ CamelContext, Message, TypeConversionException }
+import org.apache.camel.{ CamelContext, Message }
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
 
 /**
@@ -34,7 +34,7 @@ case class StreamMessage[A](body: A, headers: Map[String, Any] = Map.empty) {
   /**
    * Returns the `body` converted to type `B` using a Camel type converter.
    *
-   * @throws TypeConversionException if type conversion fails.
+   * @throws org.apache.camel.TypeConversionException if type conversion fails.
    */
   def bodyAs[B](implicit streamContext: StreamContext, tag: ClassTag[B]): B =
     streamContext.convertObject(body)
@@ -43,7 +43,7 @@ case class StreamMessage[A](body: A, headers: Map[String, Any] = Map.empty) {
    * Returns the `name` header value converted to type `B` using a Camel type converter.
    *
    * @throws NoSuchElementException if the `name` header does not exist.
-   * @throws TypeConversionException if type conversion fails.
+   * @throws org.apache.camel.TypeConversionException if type conversion fails.
    */
   def headerAs[B](name: String)(implicit streamContext: StreamContext, tag: ClassTag[B]): B =
     headerOptionAs[B](name).get
@@ -52,7 +52,7 @@ case class StreamMessage[A](body: A, headers: Map[String, Any] = Map.empty) {
    * Returns the `name` header value converted to type `B` using a Camel type converter
    * if the `name` header is defined.
    *
-   * @throws TypeConversionException if type conversion fails.
+   * @throws org.apache.camel.TypeConversionException if type conversion fails.
    */
   def headerOptionAs[B](name: String)(implicit streamContext: StreamContext, tag: ClassTag[B]): Option[B] =
     headers.get(name).map(streamContext.convertObject[B])
@@ -78,7 +78,7 @@ case class StreamMessage[A](body: A, headers: Map[String, Any] = Map.empty) {
    *
    * Returns the `body` converted to type `B` using a Camel type converter.
    *
-   * @throws TypeConversionException if type conversion fails.
+   * @throws org.apache.camel.TypeConversionException if type conversion fails.
    */
   def getBodyAs[B](streamContext: StreamContext, clazz: Class[B]): B =
     bodyAs(streamContext, ClassTag(clazz))
@@ -89,7 +89,7 @@ case class StreamMessage[A](body: A, headers: Map[String, Any] = Map.empty) {
    * Returns the `name` header value converted to type `B` using a Camel type converter.
    *
    * @throws NoSuchElementException if the `name` header does not exist.
-   * @throws TypeConversionException if type conversion fails.
+   * @throws org.apache.camel.TypeConversionException if type conversion fails.
    */
   def getHeaderAs[B](name: String, streamContext: StreamContext, clazz: Class[B]): B =
     headerAs(name)(streamContext, ClassTag(clazz))
@@ -100,7 +100,7 @@ case class StreamMessage[A](body: A, headers: Map[String, Any] = Map.empty) {
    * Returns the `name` header value converted to type `B` using a Camel type converter
    * if the `name` header is defined.
    *
-   * @throws TypeConversionException if type conversion fails.
+   * @throws org.apache.camel.TypeConversionException if type conversion fails.
    */
   def getHeaderOptionAs[B](name: String, streamContext: StreamContext, clazz: Class[B]): Optional[B] =
     Optional.ofNullable(headerOptionAs(name)(streamContext, ClassTag(clazz)).getOrElse(null.asInstanceOf[B]))
@@ -128,7 +128,7 @@ object StreamMessage {
    * Creates a [[StreamMessage]] from a Camel [[Message]] converting the message body to type `A`
    * using a Camel type converter.
    *
-   * @throws TypeConversionException if type conversion fails.
+   * @throws org.apache.camel.TypeConversionException if type conversion fails.
    */
   private[camel] def from[A](camelMessage: Message)(implicit tag: ClassTag[A]): StreamMessage[A] =
     new StreamMessage(camelMessage.getBody(tag.runtimeClass.asInstanceOf[Class[A]]), camelMessage.getHeaders.asScala.toMap)

--- a/streamz-camel-context/src/test/scala/streamz/camel/StreamMessageSpec.scala
+++ b/streamz-camel-context/src/test/scala/streamz/camel/StreamMessageSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2018 the original author or authors.
+ * Copyright 2014 - 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-camel-fs2/src/test/scala/streamz/camel/fs2/dsl/DslSpec.scala
+++ b/streamz-camel-fs2/src/test/scala/streamz/camel/fs2/dsl/DslSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2018 the original author or authors.
+ * Copyright 2014 - 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ class DslSpec extends WordSpec with Matchers with BeforeAndAfterAll {
   override protected def beforeAll(): Unit = {
     camelContext.start()
     streamContext.start()
+    ()
   }
 
   override protected def afterAll(): Unit = {

--- a/streamz-converter/build.sbt
+++ b/streamz-converter/build.sbt
@@ -2,6 +2,7 @@ name := "streamz-converter"
 
 libraryDependencies ++= Seq(
   "co.fs2"            %% "fs2-core"            % Version.Fs2,
+  "org.typelevel"     %% "cats-effect"         % Version.CatsEffect,
   "com.typesafe.akka" %% "akka-stream"         % Version.Akka,
   "com.typesafe.akka" %% "akka-stream-testkit" % Version.Akka % "test",
   "com.typesafe.akka" %% "akka-testkit"        % Version.Akka % "test")

--- a/streamz-converter/src/main/scala/streamz/converter/Converter.scala
+++ b/streamz-converter/src/main/scala/streamz/converter/Converter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2018 the original author or authors.
+ * Copyright 2014 - 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,10 +20,13 @@ import akka.stream._
 import akka.stream.scaladsl.{ Flow => AkkaFlow, Sink => AkkaSink, Source => AkkaSource, _ }
 import akka.{ Done, NotUsed }
 import cats.effect._
+import cats.effect.concurrent.Deferred
+import cats.effect.implicits._
 import cats.implicits._
 import fs2._
 
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.{ Failure, Success }
 
 trait Converter {
 
@@ -44,7 +47,7 @@ trait Converter {
    * Converts an Akka Stream [[Graph]] of [[SinkShape]] to an FS2 [[Sink]]. The [[Graph]] is materialized when
    * the [[Sink]]'s [[F]] in run. The materialized value can be obtained with the `onMaterialization` callback.
    */
-  def akkaSinkToFs2Sink[F[_], A, M](sink: Graph[SinkShape[A], M])(onMaterialization: M => Unit)(implicit materializer: Materializer, F: Concurrent[F]): Sink[F, A] = { s =>
+  def akkaSinkToFs2Pipe[F[_]: ContextShift, A, M](sink: Graph[SinkShape[A], M])(onMaterialization: M => Unit)(implicit materializer: Materializer, F: Concurrent[F]): Pipe[F, A, Unit] = { s =>
     Stream.force {
       F.delay {
         val (publisher, mat) = AkkaSource.queue[A](0, OverflowStrategy.backpressure).toMat(sink)(Keep.both).run()
@@ -52,6 +55,40 @@ trait Converter {
         publisherStream[F, A](publisher, s)
       }
     }
+  }
+
+  /**
+   * Converts an akka sink with a success-status-indicating Future[M]
+   * materialized result into an fs2 Pipe which will fail if the Future fails.
+   * The stream returned by this will emit the Future's value one time at the end,
+   * then terminate.
+   */
+  def akkaSinkToFs2PipeMat[F[_]: ConcurrentEffect: ContextShift, A, M](akkaSink: Graph[SinkShape[A], Future[M]])(
+    implicit
+    ec: ExecutionContext,
+    m: Materializer): Pipe[F, A, Either[Throwable, M]] = {
+    val mkPromise = Deferred[F, Either[Throwable, M]]
+    // `Pipe` is just a function of Stream[F, A] => Stream[F, B], so we take a stream as input.
+    in =>
+      Stream.eval(mkPromise).flatMap { p =>
+        // Akka streams produce a materialized value as a side effect of being run.
+        // streamz-converters allows us to have a `Future[Done] => Unit` callback when that materialized value is created.
+        // This callback tells the akka materialized future to store its result status into the Promise
+        val captureMaterializedResult: Future[M] => Unit = _.onComplete {
+          case Failure(ex) => p.complete(Left(ex)).toIO.unsafeRunSync()
+          case Success(value) => p.complete(Right(value)).toIO.unsafeRunSync()
+        }
+        // toSink is from streamz-converters; convert an akka sink to fs2 sink with a callback for the materialized values
+        val fs2Sink: Pipe[F, A, Unit] =
+          akkaSink.toPipe[F](captureMaterializedResult)
+
+        val fs2Stream: Stream[F, Unit] = fs2Sink.apply(in)
+        val materializedResultStream: Stream[F, Either[Throwable, M]] =
+          // Async wait on the promise to be completed
+          Stream.eval(p.get)
+        // Run the akka sink for its effects and then run stream containing the effect of getting the Promise results
+        fs2Stream.drain ++ materializedResultStream
+      }
   }
 
   /**
@@ -77,7 +114,11 @@ trait Converter {
   def fs2StreamToAkkaSource[F[_]: ContextShift, A](stream: Stream[F, A])(implicit F: ConcurrentEffect[F]): Graph[SourceShape[A], NotUsed] = {
     val source = AkkaSource.queue[A](0, OverflowStrategy.backpressure)
     // A sink that runs an FS2 publisherStream when consuming the publisher actor (= materialized value) of source
-    val sink = AkkaSink.foreach[SourceQueueWithComplete[A]](p => F.toIO(publisherStream[F, A](p, stream).compile.drain).unsafeToFuture())
+    val sink = AkkaSink.foreach[SourceQueueWithComplete[A]] { p =>
+      // Fire and forget Future so it runs in the background
+      publisherStream[F, A](p, stream).compile.drain.toIO.unsafeToFuture()
+      ()
+    }
 
     AkkaSource.fromGraph(GraphDSL.create(source) { implicit builder => source =>
       import GraphDSL.Implicits._
@@ -87,18 +128,20 @@ trait Converter {
   }
 
   /**
-   * Converts an FS2 [[Sink]] to an Akka Stream [[Graph]] of [[SinkShape]]. The [[Sink]] is run when the
+   * Converts an FS2 [[Pipe]] to an Akka Stream [[Graph]] of [[SinkShape]]. The [[Sink]] is run when the
    * [[Graph]] is materialized.
    */
-  def fs2SinkToAkkaSink[F[_]: ContextShift, A](sink: Sink[F, A])(implicit F: Effect[F]): Graph[SinkShape[A], Future[Done]] = {
+  def fs2PipeToAkkaSink[F[_]: ContextShift, A](sink: Pipe[F, A, Unit])(implicit F: Effect[F]): Graph[SinkShape[A], Future[Done]] = {
     val sink1: AkkaSink[A, SinkQueueWithCancel[A]] = AkkaSink.queue[A]()
     // A sink that runs an FS2 subscriberStream when consuming the subscriber actor (= materialized value) of sink1.
     // The future returned from unsafeToFuture() completes when the subscriber stream completes and is made
     // available as materialized value of this sink.
     val sink2: AkkaSink[SinkQueueWithCancel[A], Future[Done]] = AkkaFlow[SinkQueueWithCancel[A]]
-      .map(s => F.toIO(subscriberStream[F, A](s).to(sink).compile.drain).as(Done: Done).unsafeToFuture())
+      .map(s => subscriberStream[F, A](s).through(sink).compile.drain.toIO.as(Done: Done).unsafeToFuture())
       .toMat(AkkaSink.head)(Keep.right)
-      .mapMaterializedValue(ffd => IO.fromFuture(IO.pure(ffd)).flatMap(fd => IO.fromFuture(IO.pure(fd))).unsafeToFuture())
+      .mapMaterializedValue(ffd => Async.fromFuture(Async.fromFuture(F.pure(ffd))).toIO.unsafeToFuture())
+    // fromFuture dance above is because scala 2.11 lacks Future#flatten. `pure` instead of `delay`
+    // because the future value is already strict by the time we get it.
 
     AkkaSink.fromGraph(GraphDSL.create(sink1, sink2)(Keep.both) { implicit builder => (sink1, sink2) =>
       import GraphDSL.Implicits._
@@ -116,7 +159,11 @@ trait Converter {
     val sink1: AkkaSink[A, SinkQueueWithCancel[A]] = AkkaSink.queue[A]()
     // A sink that runs an FS2 transformerStream when consuming the publisher actor (= materialized value) of source
     // and the subscriber actor (= materialized value) of sink1
-    val sink2 = AkkaSink.foreach[(SourceQueueWithComplete[B], SinkQueueWithCancel[A])](ps => F.toIO(transformerStream(ps._2, ps._1, pipe).compile.drain).unsafeToFuture())
+    val sink2 = AkkaSink.foreach[(SourceQueueWithComplete[B], SinkQueueWithCancel[A])] { ps =>
+      // Fire and forget Future so it runs in the background
+      F.toIO(transformerStream(ps._2, ps._1, pipe).compile.drain).unsafeToFuture()
+      ()
+    }
 
     AkkaFlow.fromGraph(GraphDSL.create(source, sink1)(Keep.both) { implicit builder => (source, sink1) =>
       import GraphDSL.Implicits._
@@ -125,48 +172,65 @@ trait Converter {
     }).mapMaterializedValue(_ => NotUsed)
   }
 
-  private def subscriberStream[F[_], A](subscriber: SinkQueueWithCancel[A])(implicit context: ContextShift[F], F: Async[F]): Stream[F, A] = {
-    val pull = context.shift >> F.liftIO(IO.fromFuture(IO(subscriber.pull())))
+  private def subscriberStream[F[_]: ContextShift, A](subscriber: SinkQueueWithCancel[A])(implicit F: Async[F]): Stream[F, A] = {
+    val pull = Async.fromFuture(F.delay(subscriber.pull()))
     val cancel = F.delay(subscriber.cancel())
     Stream.repeatEval(pull).unNoneTerminate.onFinalize(cancel)
   }
 
-  private def publisherStream[F[_], A](publisher: SourceQueueWithComplete[A], stream: Stream[F, A])(implicit F: Concurrent[F]): Stream[F, Unit] = {
-    def publish(a: A): F[Option[Unit]] = F.liftIO(IO.fromFuture(IO(publisher.offer(a)))).flatMap {
+  private def publisherStream[F[_]: ContextShift, A](publisher: SourceQueueWithComplete[A], stream: Stream[F, A])(implicit F: Concurrent[F]): Stream[F, Unit] = {
+    def publish(a: A): F[Option[Unit]] = Async.fromFuture(F.delay(publisher.offer(a))).flatMap {
       case QueueOfferResult.Enqueued => ().some.pure[F]
       case QueueOfferResult.Failure(cause) => F.raiseError[Option[Unit]](cause)
       case QueueOfferResult.QueueClosed => none[Unit].pure[F]
-      case QueueOfferResult.Dropped => F.raiseError[Option[Unit]](new IllegalArgumentException("This should never happen because we use OverflowStrategy.backpressure"))
+      case QueueOfferResult.Dropped => F.raiseError[Option[Unit]](new IllegalStateException("This should never happen because we use OverflowStrategy.backpressure"))
+    }.recover {
+      // This handles a race condition between `interruptWhen` and `publish`.
+      // There's no guarantee that, when the akka sink is terminated, we will observe the
+      // `interruptWhen` termination before calling publish one last time.
+      // Such a call fails with StreamDetachedException
+      case _: StreamDetachedException => none[Unit]
     }
-    def watchCompletion: F[Unit] = F.liftIO(IO.fromFuture(IO(publisher.watchCompletion())).void)
+
+    def watchCompletion: F[Unit] = Async.fromFuture(F.delay(publisher.watchCompletion())).void
     def fail(e: Throwable): F[Unit] = F.delay(publisher.fail(e)) >> watchCompletion
     def complete: F[Unit] = F.delay(publisher.complete()) >> watchCompletion
+
     stream.interruptWhen(watchCompletion.attempt).evalMap(publish).unNoneTerminate
-      .handleErrorWith { ex =>
-        Stream.eval(fail(ex)) >> Stream.raiseError[F](ex)
-      } ++ Stream.eval_(complete)
+      .onFinalizeCase {
+        case ExitCase.Completed | ExitCase.Canceled => complete
+        case ExitCase.Error(e) => fail(e)
+      }
   }
 
   private def transformerStream[F[_]: ContextShift: Concurrent, A, B](subscriber: SinkQueueWithCancel[B], publisher: SourceQueueWithComplete[A], stream: Stream[F, A]): Stream[F, B] =
     subscriberStream[F, B](subscriber).concurrently(publisherStream[F, A](publisher, stream))
 
   private def transformerStream[F[_]: ContextShift: Concurrent, A, B](subscriber: SinkQueueWithCancel[A], publisher: SourceQueueWithComplete[B], pipe: Pipe[F, A, B]): Stream[F, Unit] =
-    subscriberStream[F, A](subscriber).through(pipe).to(s => publisherStream(publisher, s))
+    subscriberStream[F, A](subscriber).through(pipe).through(s => publisherStream(publisher, s))
 }
 
 trait ConverterDsl extends Converter {
+
   implicit class AkkaSourceDsl[A, M](source: Graph[SourceShape[A], M]) {
 
-    /** @see [[Converter#akkaSourceToFs2StreamF]] */
+    /** @see [[Converter#akkaSourceToFs2Stream]] */
     def toStream[F[_]: ContextShift: Async](onMaterialization: M => Unit = _ => ())(implicit materializer: Materializer): Stream[F, A] =
       akkaSourceToFs2Stream(source)(onMaterialization)
   }
 
   implicit class AkkaSinkDsl[A, M](sink: Graph[SinkShape[A], M]) {
 
-    /** @see [[Converter#akkaSinkToFs2Sink]] */
-    def toSink[F[_]: ContextShift: Concurrent](onMaterialization: M => Unit = _ => ())(implicit materializer: Materializer): Sink[F, A] =
-      akkaSinkToFs2Sink(sink)(onMaterialization)
+    /** @see [[Converter#akkaSinkToFs2Pipe]] */
+    def toPipe[F[_]: Concurrent: ContextShift](onMaterialization: M => Unit = _ => ())(implicit materializer: Materializer): Pipe[F, A, Unit] =
+      akkaSinkToFs2Pipe(sink)(onMaterialization)
+
+  }
+
+  implicit class AkkaSinkMatDsl[A, M](sink: Graph[SinkShape[A], Future[M]]) {
+    def toPipeMat[F[_]: ConcurrentEffect: ContextShift](implicit materializer: Materializer, ec: ExecutionContext): Pipe[F, A, Either[Throwable, M]] =
+      akkaSinkToFs2PipeMat[F, A, M](sink)
+
   }
 
   implicit class AkkaFlowDsl[A, B, M](flow: Graph[FlowShape[A, B], M]) {
@@ -178,41 +242,45 @@ trait ConverterDsl extends Converter {
 
   implicit class FS2StreamNothingDsl[A](stream: Stream[Nothing, A]) {
 
-    /** @see [[Converter#fs2StreamToAkkaSourceF]] */
+    /** @see [[Converter#fs2StreamToAkkaSource]] */
+    @deprecated("Use `stream.covary[F].toSource` instead", "0.10")
     def toSource(implicit contextShift: ContextShift[IO]): Graph[SourceShape[A], NotUsed] =
       fs2StreamToAkkaSource(stream: Stream[IO, A])
   }
 
   implicit class FS2StreamPureDsl[A](stream: Stream[Pure, A]) {
 
-    /** @see [[Converter#fs2StreamToAkkaSourceF]] */
+    /** @see [[Converter#fs2StreamToAkkaSource]] */
+    @deprecated("Use `stream.covary[F].toSource` instead", "0.10")
     def toSource(implicit contextShift: ContextShift[IO]): Graph[SourceShape[A], NotUsed] =
       fs2StreamToAkkaSource(stream: Stream[IO, A])
   }
 
   implicit class FS2StreamIODsl[F[_]: ContextShift: ConcurrentEffect, A](stream: Stream[F, A]) {
 
-    /** @see [[Converter#fs2StreamToAkkaSourceF]] */
+    /** @see [[Converter#fs2StreamToAkkaSource]] */
     def toSource: Graph[SourceShape[A], NotUsed] =
       fs2StreamToAkkaSource(stream)
   }
 
-  implicit class FS2SinkPureDsl[A](sink: Sink[Pure, A]) {
+  implicit class FS2SinkPureDsl[A](sink: Pipe[Pure, A, Unit]) {
 
-    /** @see [[Converter#fs2SinkToAkkaSink]] */
+    /** @see [[Converter#fs2PipeToAkkaSink]] */
+    @deprecated("Use `pipe.covary[F].toSink` instead", "0.10")
     def toSink(implicit contextShift: ContextShift[IO]): Graph[SinkShape[A], Future[Done]] =
-      fs2SinkToAkkaSink(sink: Sink[IO, A])
+      fs2PipeToAkkaSink(sink.covary[IO])
   }
 
-  implicit class FS2SinkIODsl[F[_]: ContextShift: Effect, A](sink: Sink[F, A]) {
-    /** @see [[Converter#fs2SinkToAkkaSink]] */
+  implicit class FS2SinkIODsl[F[_]: Effect: ContextShift, A](sink: Pipe[F, A, Unit]) {
+    /** @see [[Converter#fs2PipeToAkkaSink]] */
     def toSink: Graph[SinkShape[A], Future[Done]] =
-      fs2SinkToAkkaSink(sink)
+      fs2PipeToAkkaSink(sink)
   }
 
   implicit class FS2PipePureDsl[A, B](pipe: Pipe[Pure, A, B]) {
 
     /** @see [[Converter#fs2PipeToAkkaFlow]] */
+    @deprecated("Use `(pipe: Pipe[F, A, B]).toFlow` instead", "0.10")
     def toFlow(implicit contextShift: ContextShift[IO]): Graph[FlowShape[A, B], NotUsed] =
       fs2PipeToAkkaFlow(pipe: Pipe[IO, A, B])
   }

--- a/streamz-converter/src/main/scala/streamz/converter/package.scala
+++ b/streamz-converter/src/main/scala/streamz/converter/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2018 the original author or authors.
+ * Copyright 2014 - 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,3 +17,4 @@
 package streamz
 
 package object converter extends ConverterDsl
+

--- a/streamz-examples/build.sbt
+++ b/streamz-examples/build.sbt
@@ -8,3 +8,14 @@ libraryDependencies ++= Seq(
   "org.apache.logging.log4j" % "log4j-core"       % Version.Log4j,
   "org.apache.logging.log4j" % "log4j-slf4j-impl" % Version.Log4j
 )
+
+// We need to silence unused-import warning on scala 2.13,
+// because scala-collection-compat library generates empty importable objects.
+scalacOptions -= "-Wunused:imports"
+scalacOptions --= {
+  if (scalaVersion.value.startsWith("2.11"))
+    // Deprecation warnings can't be disabled, so we have to remove fatal-warnings to allow use of `String#linesIterator`
+    Seq("-Xfatal-warnings")
+  else
+    Seq()
+}

--- a/streamz-examples/src/main/java/streamz/examples/camel/akka/JExample.java
+++ b/streamz-examples/src/main/java/streamz/examples/camel/akka/JExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2018 the original author or authors.
+ * Copyright 2014 - 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-examples/src/main/java/streamz/examples/camel/akka/JExampleContext.java
+++ b/streamz-examples/src/main/java/streamz/examples/camel/akka/JExampleContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2018 the original author or authors.
+ * Copyright 2014 - 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-examples/src/main/java/streamz/examples/camel/akka/JGreeter.java
+++ b/streamz-examples/src/main/java/streamz/examples/camel/akka/JGreeter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2018 the original author or authors.
+ * Copyright 2014 - 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-examples/src/main/java/streamz/examples/camel/akka/JSnippets.java
+++ b/streamz-examples/src/main/java/streamz/examples/camel/akka/JSnippets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2018 the original author or authors.
+ * Copyright 2014 - 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-examples/src/main/scala/streamz/examples/camel/ExampleContext.scala
+++ b/streamz-examples/src/main/scala/streamz/examples/camel/ExampleContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2018 the original author or authors.
+ * Copyright 2014 - 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-examples/src/main/scala/streamz/examples/camel/akka/Example.scala
+++ b/streamz-examples/src/main/scala/streamz/examples/camel/akka/Example.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2018 the original author or authors.
+ * Copyright 2014 - 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import streamz.camel.akka.scaladsl._
 import streamz.examples.camel.ExampleContext
 
 import scala.collection.immutable.Iterable
+import scala.collection.compat._
 
 object Example extends ExampleContext with App {
   implicit val system = ActorSystem("example")
@@ -34,7 +35,7 @@ object Example extends ExampleContext with App {
     receiveBody[String](tcpEndpointUri)
 
   val fileLineSource: Source[String, NotUsed] =
-    receiveBody[String](fileEndpointUri).mapConcat(_.lines.to[Iterable])
+    receiveBody[String](fileEndpointUri).mapConcat(_.linesIterator.to(Iterable))
 
   val linePrefixSource: Source[String, NotUsed] =
     Source.fromIterator(() => Iterator.from(1)).sendRequest[String](serviceEndpointUri)

--- a/streamz-examples/src/main/scala/streamz/examples/camel/akka/Greeter.scala
+++ b/streamz-examples/src/main/scala/streamz/examples/camel/akka/Greeter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2018 the original author or authors.
+ * Copyright 2014 - 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-examples/src/main/scala/streamz/examples/camel/akka/Snippets.scala
+++ b/streamz-examples/src/main/scala/streamz/examples/camel/akka/Snippets.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2018 the original author or authors.
+ * Copyright 2014 - 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,11 +65,11 @@ object Snippets extends App {
   val s2bv: Source[String, NotUsed] = s1b.via(sendBody("seda:q2"))
   val s3bv: Source[Int, NotUsed] = s2b.via(sendRequestBody[String, Int]("bean:service?method=weight"))
 
-  val f1: Flow[String, StreamMessage[String], NotUsed] = ???
+  def f1: Flow[String, StreamMessage[String], NotUsed] = ???
   val f2: Flow[String, StreamMessage[String], NotUsed] = f1.send("seda:q2")
   val f3: Flow[String, StreamMessage[Int], NotUsed] = f2.sendRequest[Int]("bean:service?method=weight")
 
-  val f1b: Flow[String, String, NotUsed] = ???
+  def f1b: Flow[String, String, NotUsed] = ???
   val f2b: Flow[String, String, NotUsed] = f1b.send("seda:q2")
   val f3b: Flow[String, Int, NotUsed] = f2b.sendRequest[Int]("bean:service?method=weight")
 }

--- a/streamz-examples/src/main/scala/streamz/examples/camel/fs2/Example.scala
+++ b/streamz-examples/src/main/scala/streamz/examples/camel/fs2/Example.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2018 the original author or authors.
+ * Copyright 2014 - 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streamz-examples/src/main/scala/streamz/examples/camel/fs2/Snippets.scala
+++ b/streamz-examples/src/main/scala/streamz/examples/camel/fs2/Snippets.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2018 the original author or authors.
+ * Copyright 2014 - 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
- Upgrade to cats-effect 2.x, fs2 1.1.x
- Add api to avoid dropping Future[Mat] values
- Deprecate apis hardcoding `IO`
- Fix race condition in akka-fs2 `publisherStream` between interruption
  and publish when using the fromFuture+ContextShift.shift behavior
- Test changes to make wording match assertions better
- Add scala-collection-compat for camel converter crossbuilding
- Bump version for milestone release
- Include sbt-tpolecat plugin to prevent lintable bugs

Ref #61 
Close #62