### PR TITLE
add implicit argument to `toSource` (`Converter.scala#L19`)

### DIFF
--- a/streamz-converter/src/main/scala/streamz/converter/Converter.scala
+++ b/streamz-converter/src/main/scala/streamz/converter/Converter.scala
@@ -193,7 +193,7 @@ trait ConverterDsl extends Converter {
   implicit class FS2StreamIODsl[F[_]: ContextShift: ConcurrentEffect, A](stream: Stream[F, A]) {
 
     /** @see [[Converter#fs2StreamToAkkaSourceF]] */
-    def toSource: Graph[SourceShape[A], NotUsed] =
+    def toSource(implicit contextShift: ContextShift[IO]): Graph[SourceShape[A], NotUsed] =
       fs2StreamToAkkaSource(stream)
   }
 


### PR DESCRIPTION
closes #62 