### PR TITLE
Use Bintray repository for resolvers in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Dependencies
 
 Streamz artifacts are available for Scala 2.12 and 2.13 at:
 
-    resolvers += "streamz at bintray" at "http://dl.bintray.com/streamz/maven"
+    resolvers += Resolver.bintrayRepo("streamz", "maven")
     val streamzVersion = "0.13"
 
     libraryDependencies ++= Seq(

--- a/streamz-camel-akka/README.md
+++ b/streamz-camel-akka/README.md
@@ -7,7 +7,7 @@ Camel DSL for Akka Streams
 
 The DSL is provided by the `streamz-camel-akka` artifact which is available for Scala 2.11 and 2.12:
 
-    resolvers += "krasserm at bintray" at "http://dl.bintray.com/krasserm/maven"
+    resolvers += Resolver.bintrayRepo("streamz", "maven")
 
     libraryDependencies += "com.github.krasserm" %% "streamz-camel-akka" % "0.10-M2"
 

--- a/streamz-camel-akka/README.md
+++ b/streamz-camel-akka/README.md
@@ -7,7 +7,7 @@ Camel DSL for Akka Streams
 
 The DSL is provided by the `streamz-camel-akka` artifact which is available for Scala 2.11 and 2.12:
 
-    resolvers += Resolver.bintrayRepo("streamz", "maven")
+    resolvers += Resolver.bintrayRepo("krasserm", "maven")
 
     libraryDependencies += "com.github.krasserm" %% "streamz-camel-akka" % "0.10-M2"
 
@@ -358,4 +358,3 @@ public interface JavaDsl {
 ```
 
 `sendBody` wraps a message of type `A` as message body into a `StreamMessage[A]` before sending it to the endpoint and continues the stream with the unwrapped message body `B` of the output `StreamMessage[B]`.
-

--- a/streamz-camel-fs2/README.md
+++ b/streamz-camel-fs2/README.md
@@ -7,7 +7,7 @@ Camel DSL for FS2
 
 The DSL is provided by the `streamz-camel-fs2` artifact which is available for Scala 2.11 and 2.12:
 
-    resolvers += Resolver.bintrayRepo("streamz", "maven")
+    resolvers += Resolver.bintrayRepo("krasserm", "maven")
 
     libraryDependencies += "com.github.krasserm" %% "streamz-camel-fs2" % "0.10-M2"
     

--- a/streamz-camel-fs2/README.md
+++ b/streamz-camel-fs2/README.md
@@ -7,7 +7,7 @@ Camel DSL for FS2
 
 The DSL is provided by the `streamz-camel-fs2` artifact which is available for Scala 2.11 and 2.12:
 
-    resolvers += "krasserm at bintray" at "http://dl.bintray.com/krasserm/maven"
+    resolvers += Resolver.bintrayRepo("streamz", "maven")
 
     libraryDependencies += "com.github.krasserm" %% "streamz-camel-fs2" % "0.10-M2"
     

--- a/streamz-converter/README.md
+++ b/streamz-converter/README.md
@@ -3,7 +3,7 @@ Stream converters
 
 Stream converters convert Akka Stream `Source`s, `Flow`s and `Sink`s to FS2 `Stream`s, `Pipe`s and `Sink`s, respectively, and vice versa. They are provided by the
 
-    resolvers += Resolver.bintrayRepo("streamz", "maven")
+    resolvers += Resolver.bintrayRepo("krasserm", "maven")
 
     libraryDependencies += "com.github.krasserm" %% "streamz-converter" % "0.11-RC1"
 
@@ -116,4 +116,3 @@ assert(Await.result(aSource2.via(aFlow2).toMat(AkkaSink.seq)(Keep.right).run(), 
 ### Backpressure, cancellation, completion and errors
 
 Downstream demand and cancellation as well as upstream completion and error signals are properly mediated between Akka Stream and FS2 (see also [ConverterSpec](https://github.com/krasserm/streamz/blob/master/streamz-converter/src/test/scala/streamz/converter/ConverterSpec.scala)).
-

--- a/streamz-converter/README.md
+++ b/streamz-converter/README.md
@@ -3,7 +3,7 @@ Stream converters
 
 Stream converters convert Akka Stream `Source`s, `Flow`s and `Sink`s to FS2 `Stream`s, `Pipe`s and `Sink`s, respectively, and vice versa. They are provided by the
 
-    resolvers += "krasserm at bintray" at "http://dl.bintray.com/krasserm/maven"
+    resolvers += Resolver.bintrayRepo("streamz", "maven")
 
     libraryDependencies += "com.github.krasserm" %% "streamz-converter" % "0.11-RC1"
 


### PR DESCRIPTION
The SBT since 1.4.0 prohibits to use [HTTP resolvers without explicit opt-in](https://github.com/sbt/sbt/releases/tag/v1.4.0). 